### PR TITLE
Upgrade Bashio to v0.8.1

### DIFF
--- a/alpine/aarch64/Dockerfile
+++ b/alpine/aarch64/Dockerfile
@@ -11,7 +11,7 @@ ENV LANG C.UTF-8
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # Base system
-ARG BASHIO_VERSION=0.8.0
+ARG BASHIO_VERSION=0.8.1
 RUN apk add --no-cache \
         bash \
         jq \

--- a/alpine/amd64/Dockerfile
+++ b/alpine/amd64/Dockerfile
@@ -8,7 +8,7 @@ ENV LANG C.UTF-8
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # Base system
-ARG BASHIO_VERSION=0.8.0
+ARG BASHIO_VERSION=0.8.1
 RUN apk add --no-cache \
         bash \
         jq \

--- a/alpine/armhf/Dockerfile
+++ b/alpine/armhf/Dockerfile
@@ -11,7 +11,7 @@ ENV LANG C.UTF-8
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # Base system
-ARG BASHIO_VERSION=0.8.0
+ARG BASHIO_VERSION=0.8.1
 RUN apk add --no-cache \
         bash \
         jq \

--- a/alpine/armv7/Dockerfile
+++ b/alpine/armv7/Dockerfile
@@ -11,7 +11,7 @@ ENV LANG C.UTF-8
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # Base system
-ARG BASHIO_VERSION=0.8.0
+ARG BASHIO_VERSION=0.8.1
 RUN apk add --no-cache \
         bash \
         jq \

--- a/alpine/i386/Dockerfile
+++ b/alpine/i386/Dockerfile
@@ -8,7 +8,7 @@ ENV LANG C.UTF-8
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # Base system
-ARG BASHIO_VERSION=0.8.0
+ARG BASHIO_VERSION=0.8.1
 RUN apk add --no-cache \
         bash \
         jq \

--- a/debian/aarch64/Dockerfile
+++ b/debian/aarch64/Dockerfile
@@ -12,7 +12,7 @@ ENV DEBIAN_FRONTEND noninteractive
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
-ARG BASHIO_VERSION=0.8.0
+ARG BASHIO_VERSION=0.8.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/debian/amd64/Dockerfile
+++ b/debian/amd64/Dockerfile
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND noninteractive
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
-ARG BASHIO_VERSION=0.8.0
+ARG BASHIO_VERSION=0.8.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/debian/armhf/Dockerfile
+++ b/debian/armhf/Dockerfile
@@ -13,7 +13,7 @@ ENV CURL_CA_BUNDLE /etc/ssl/certs/ca-certificates.crt
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
-ARG BASHIO_VERSION=0.8.0
+ARG BASHIO_VERSION=0.8.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/debian/armv7/Dockerfile
+++ b/debian/armv7/Dockerfile
@@ -13,7 +13,7 @@ ENV CURL_CA_BUNDLE /etc/ssl/certs/ca-certificates.crt
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
-ARG BASHIO_VERSION=0.8.0
+ARG BASHIO_VERSION=0.8.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/debian/i386/Dockerfile
+++ b/debian/i386/Dockerfile
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND noninteractive
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
-ARG BASHIO_VERSION=0.8.0
+ARG BASHIO_VERSION=0.8.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/raspbian/Dockerfile
+++ b/raspbian/Dockerfile
@@ -13,7 +13,7 @@ ENV CURL_CA_BUNDLE /etc/ssl/certs/ca-certificates.crt
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
-ARG BASHIO_VERSION=0.8.0
+ARG BASHIO_VERSION=0.8.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/ubuntu/aarch64/Dockerfile
+++ b/ubuntu/aarch64/Dockerfile
@@ -12,7 +12,7 @@ ENV DEBIAN_FRONTEND noninteractive
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
-ARG BASHIO_VERSION=0.8.0
+ARG BASHIO_VERSION=0.8.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/ubuntu/amd64/Dockerfile
+++ b/ubuntu/amd64/Dockerfile
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND noninteractive
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
-ARG BASHIO_VERSION=0.8.0
+ARG BASHIO_VERSION=0.8.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/ubuntu/armv7/Dockerfile
+++ b/ubuntu/armv7/Dockerfile
@@ -12,7 +12,7 @@ ENV DEBIAN_FRONTEND noninteractive
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
-ARG BASHIO_VERSION=0.8.0
+ARG BASHIO_VERSION=0.8.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/ubuntu/i386/Dockerfile
+++ b/ubuntu/i386/Dockerfile
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND noninteractive
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
-ARG BASHIO_VERSION=0.8.0
+ARG BASHIO_VERSION=0.8.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \


### PR DESCRIPTION
Upgrade Bashio to v0.8.1

Fixes a small bug in the services API.