### PR TITLE
Upgrade S6 Overlay to 2.0.0.1

### DIFF
--- a/alpine/aarch64/Dockerfile
+++ b/alpine/aarch64/Dockerfile
@@ -15,7 +15,7 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # Base system
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=1.22.1.0
+ARG S6_OVERLAY_VERSION=2.0.0.1
 RUN apk add --no-cache \
         bash \
         jq \

--- a/alpine/amd64/Dockerfile
+++ b/alpine/amd64/Dockerfile
@@ -12,7 +12,7 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # Base system
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=1.22.1.0
+ARG S6_OVERLAY_VERSION=2.0.0.1
 RUN apk add --no-cache \
         bash \
         jq \

--- a/alpine/armhf/Dockerfile
+++ b/alpine/armhf/Dockerfile
@@ -15,7 +15,7 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # Base system
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=1.22.1.0
+ARG S6_OVERLAY_VERSION=2.0.0.1
 RUN apk add --no-cache \
         bash \
         jq \

--- a/alpine/armv7/Dockerfile
+++ b/alpine/armv7/Dockerfile
@@ -15,7 +15,7 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # Base system
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=1.22.1.0
+ARG S6_OVERLAY_VERSION=2.0.0.1
 RUN apk add --no-cache \
         bash \
         jq \

--- a/alpine/i386/Dockerfile
+++ b/alpine/i386/Dockerfile
@@ -12,7 +12,7 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # Base system
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=1.22.1.0
+ARG S6_OVERLAY_VERSION=2.0.0.1
 RUN apk add --no-cache \
         bash \
         jq \

--- a/debian/aarch64/Dockerfile
+++ b/debian/aarch64/Dockerfile
@@ -16,7 +16,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=1.22.1.0
+ARG S6_OVERLAY_VERSION=2.0.0.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/debian/amd64/Dockerfile
+++ b/debian/amd64/Dockerfile
@@ -13,7 +13,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=1.22.1.0
+ARG S6_OVERLAY_VERSION=2.0.0.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/debian/armhf/Dockerfile
+++ b/debian/armhf/Dockerfile
@@ -17,7 +17,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=1.22.1.0
+ARG S6_OVERLAY_VERSION=2.0.0.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/debian/armv7/Dockerfile
+++ b/debian/armv7/Dockerfile
@@ -17,7 +17,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=1.22.1.0
+ARG S6_OVERLAY_VERSION=2.0.0.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/debian/i386/Dockerfile
+++ b/debian/i386/Dockerfile
@@ -13,7 +13,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=1.22.1.0
+ARG S6_OVERLAY_VERSION=2.0.0.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/raspbian/Dockerfile
+++ b/raspbian/Dockerfile
@@ -17,7 +17,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=1.22.1.0
+ARG S6_OVERLAY_VERSION=2.0.0.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/ubuntu/aarch64/Dockerfile
+++ b/ubuntu/aarch64/Dockerfile
@@ -16,7 +16,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=1.22.1.0
+ARG S6_OVERLAY_VERSION=2.0.0.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/ubuntu/amd64/Dockerfile
+++ b/ubuntu/amd64/Dockerfile
@@ -13,7 +13,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=1.22.1.0
+ARG S6_OVERLAY_VERSION=2.0.0.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/ubuntu/armv7/Dockerfile
+++ b/ubuntu/armv7/Dockerfile
@@ -16,7 +16,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=1.22.1.0
+ARG S6_OVERLAY_VERSION=2.0.0.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/ubuntu/i386/Dockerfile
+++ b/ubuntu/i386/Dockerfile
@@ -13,7 +13,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=1.22.1.0
+ARG S6_OVERLAY_VERSION=2.0.0.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \


### PR DESCRIPTION
Upgrade notes: https://github.com/just-containers/s6-overlay#upgrade-notes

Upgraded all community add-ons (edge versions) already, no adjustments needed on our end.