### PR TITLE
Optimize python with LTO & no-semantic

### DIFF
--- a/python/3.6/Dockerfile
+++ b/python/3.6/Dockerfile
@@ -78,8 +78,8 @@ RUN set -ex \
         --with-system-ffi \
         --without-ensurepip \
     && make -j "$(nproc)" \
-        LDFLAGS="-Wl,--strip-all -L`jemalloc-config --libdir` -Wl,-rpath,`jemalloc-config --libdir` -ljemalloc `jemalloc-config --libs`" \
-        CFLAGS="-fno-semantic-interposition" \
+        LDFLAGS="-Wl,--strip-all" \
+        CFLAGS="-fno-semantic-interposition -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -ljemalloc" \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
         EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \

--- a/python/3.6/Dockerfile
+++ b/python/3.6/Dockerfile
@@ -41,7 +41,7 @@ RUN set -ex \
         dpkg-dev dpkg \
         expat-dev \
         findutils \
-        gcc \
+        build-base \
         gdbm-dev \
         libc-dev \
         libffi-dev \
@@ -73,14 +73,16 @@ RUN set -ex \
         --enable-loadable-sqlite-extensions \
         --enable-optimizations \
         --enable-shared \
+        --with-lto \
         --with-system-expat \
         --with-system-ffi \
         --without-ensurepip \
     && make -j "$(nproc)" \
+        LDFLAGS="-Wl,--strip-all -L`jemalloc-config --libdir` -Wl,-rpath,`jemalloc-config --libdir` -ljemalloc `jemalloc-config --libs`" \
+        CFLAGS="-fno-semantic-interposition" \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
         EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-        LDFLAGS="-Wl,--strip-all" \
 # setting PROFILE_TASK makes "--enable-optimizations" reasonable: https://bugs.python.org/issue36044
         PROFILE_TASK='-m test.regrtest --pgo \
             test_asyncio \

--- a/python/3.7/Dockerfile
+++ b/python/3.7/Dockerfile
@@ -78,8 +78,8 @@ RUN set -ex \
         --with-system-ffi \
         --without-ensurepip \
     && make -j "$(nproc)" \
-        LDFLAGS="-Wl,--strip-all -L`jemalloc-config --libdir` -Wl,-rpath,`jemalloc-config --libdir` -ljemalloc `jemalloc-config --libs`" \
-        CFLAGS="-fno-semantic-interposition" \
+        LDFLAGS="-Wl,--strip-all" \
+        CFLAGS="-fno-semantic-interposition -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -ljemalloc" \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
         EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \

--- a/python/3.7/Dockerfile
+++ b/python/3.7/Dockerfile
@@ -41,7 +41,7 @@ RUN set -ex \
         dpkg-dev dpkg \
         expat-dev \
         findutils \
-        gcc \
+        build-base \
         gdbm-dev \
         libc-dev \
         libffi-dev \
@@ -73,14 +73,16 @@ RUN set -ex \
         --enable-loadable-sqlite-extensions \
         --enable-optimizations \
         --enable-shared \
+        --with-lto \
         --with-system-expat \
         --with-system-ffi \
         --without-ensurepip \
     && make -j "$(nproc)" \
+        LDFLAGS="-Wl,--strip-all -L`jemalloc-config --libdir` -Wl,-rpath,`jemalloc-config --libdir` -ljemalloc `jemalloc-config --libs`" \
+        CFLAGS="-fno-semantic-interposition" \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
         EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-        LDFLAGS="-Wl,--strip-all" \
 # setting PROFILE_TASK makes "--enable-optimizations" reasonable: https://bugs.python.org/issue36044
 		PROFILE_TASK='-m test.regrtest --pgo \
             test_asyncio \

--- a/python/3.7/arm-alignment.patch
+++ b/python/3.7/arm-alignment.patch
@@ -1,0 +1,17 @@
+Author: Dave Jones <dave.jones@canonical.com>
+Description: Use aligned access for _sha3 module on ARM.
+--- a/Modules/_sha3/sha3module.c
++++ b/Modules/_sha3/sha3module.c
+@@ -64,6 +64,12 @@
+ #define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
+ #endif
+ 
++/* Bus error on 32-bit ARM due to un-aligned memory accesses; 64-bit ARM
++ * doesn't complain but un-aligned memory accesses are sub-optimal */
++#if defined(__arm__) || defined(__aarch64__)
++#define NO_MISALIGNED_ACCESSES
++#endif
++
+ /* mangle names */
+ #define KeccakF1600_FastLoop_Absorb _PySHA3_KeccakF1600_FastLoop_Absorb
+ #define Keccak_HashFinal _PySHA3_Keccak_HashFinal

--- a/python/3.8/Dockerfile
+++ b/python/3.8/Dockerfile
@@ -78,8 +78,8 @@ RUN set -ex \
         --with-system-ffi \
         --without-ensurepip \
     && make -j "$(nproc)" \
-        LDFLAGS="-Wl,--strip-all -L`jemalloc-config --libdir` -Wl,-rpath,`jemalloc-config --libdir` -ljemalloc `jemalloc-config --libs`" \
-        CFLAGS="-fno-semantic-interposition" \
+        LDFLAGS="-Wl,--strip-all" \
+        CFLAGS="-fno-semantic-interposition -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -ljemalloc" \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
         EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \

--- a/python/3.8/Dockerfile
+++ b/python/3.8/Dockerfile
@@ -41,7 +41,7 @@ RUN set -ex \
         dpkg-dev dpkg \
         expat-dev \
         findutils \
-        gcc \
+        build-base \
         gdbm-dev \
         libc-dev \
         libffi-dev \
@@ -73,14 +73,16 @@ RUN set -ex \
         --enable-loadable-sqlite-extensions \
         --enable-optimizations \
         --enable-shared \
+        --with-lto \
         --with-system-expat \
         --with-system-ffi \
         --without-ensurepip \
     && make -j "$(nproc)" \
+        LDFLAGS="-Wl,--strip-all -L`jemalloc-config --libdir` -Wl,-rpath,`jemalloc-config --libdir` -ljemalloc `jemalloc-config --libs`" \
+        CFLAGS="-fno-semantic-interposition" \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
         EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
-        LDFLAGS="-Wl,--strip-all" \
     && make install \
     \
 	&& find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec scanelf --needed --nobanner --format '%n#p' '{}' ';' \

--- a/python/3.8/arm-alignment.patch
+++ b/python/3.8/arm-alignment.patch
@@ -1,0 +1,17 @@
+Author: Dave Jones <dave.jones@canonical.com>
+Description: Use aligned access for _sha3 module on ARM.
+--- a/Modules/_sha3/sha3module.c
++++ b/Modules/_sha3/sha3module.c
+@@ -64,6 +64,12 @@
+ #define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
+ #endif
+ 
++/* Bus error on 32-bit ARM due to un-aligned memory accesses; 64-bit ARM
++ * doesn't complain but un-aligned memory accesses are sub-optimal */
++#if defined(__arm__) || defined(__aarch64__)
++#define NO_MISALIGNED_ACCESSES
++#endif
++
+ /* mangle names */
+ #define KeccakF1600_FastLoop_Absorb _PySHA3_KeccakF1600_FastLoop_Absorb
+ #define Keccak_HashFinal _PySHA3_Keccak_HashFinal


### PR DESCRIPTION
- https://developers.redhat.com/blog/2020/06/25/red-hat-enterprise-linux-8-2-brings-faster-python-3-8-run-speeds/?sc_cid=7013a000002DTukAAG
- https://github.com/jemalloc/jemalloc/wiki/Getting-Started
- Enable strip binary
- Disable built-in optimazion for memory because we use jemalloc

Result:
https://pastebin.com/QKzXPqwF

Note:
The improvement with fno-semantic-interposition is pretty small because GCC 9.x handle it different, anyway we do not loose anything now with GCC 9.x and can use it with static linking jemalloc into library.