### PR TITLE
Upgrade Python to 3.8.5

### DIFF
--- a/python/3.8/Dockerfile
+++ b/python/3.8/Dockerfile
@@ -12,7 +12,7 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 RUN apk add --no-cache ca-certificates
 
 ENV GPG_KEY E3FF2839C048B25C084DEBE9B26995E310250568
-ENV PYTHON_VERSION 3.8.4
+ENV PYTHON_VERSION 3.8.5
 
 COPY *.patch /usr/src/
 RUN set -ex \


### PR DESCRIPTION
Upgrades Python from 3.8.4 to 3.8.5

Release notes: <https://www.python.org/downloads/release/python-385/>