### PR TITLE
Upgrade S6 Overlay to 2.1.0.0

### DIFF
--- a/alpine/aarch64/Dockerfile
+++ b/alpine/aarch64/Dockerfile
@@ -15,7 +15,7 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # Version
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=2.0.0.1
+ARG S6_OVERLAY_VERSION=2.1.0.0
 ARG JEMALLOC_VERSION=5.2.1
 
 # Base system

--- a/alpine/amd64/Dockerfile
+++ b/alpine/amd64/Dockerfile
@@ -12,7 +12,7 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # Version
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=2.0.0.1
+ARG S6_OVERLAY_VERSION=2.1.0.0
 ARG JEMALLOC_VERSION=5.2.1
 
 # Base system

--- a/alpine/armhf/Dockerfile
+++ b/alpine/armhf/Dockerfile
@@ -15,7 +15,7 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # Version
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=2.0.0.1
+ARG S6_OVERLAY_VERSION=2.1.0.0
 ARG JEMALLOC_VERSION=5.2.1
 
 # Base system

--- a/alpine/armv7/Dockerfile
+++ b/alpine/armv7/Dockerfile
@@ -15,7 +15,7 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # Version
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=2.0.0.1
+ARG S6_OVERLAY_VERSION=2.1.0.0
 ARG JEMALLOC_VERSION=5.2.1
 
 # Base system

--- a/alpine/i386/Dockerfile
+++ b/alpine/i386/Dockerfile
@@ -12,7 +12,7 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # Version
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=2.0.0.1
+ARG S6_OVERLAY_VERSION=2.1.0.0
 ARG JEMALLOC_VERSION=5.2.1
 
 # Base system

--- a/debian/aarch64/Dockerfile
+++ b/debian/aarch64/Dockerfile
@@ -16,7 +16,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=2.0.0.1
+ARG S6_OVERLAY_VERSION=2.1.0.0
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/debian/amd64/Dockerfile
+++ b/debian/amd64/Dockerfile
@@ -13,7 +13,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=2.0.0.1
+ARG S6_OVERLAY_VERSION=2.1.0.0
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/debian/armhf/Dockerfile
+++ b/debian/armhf/Dockerfile
@@ -17,7 +17,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=2.0.0.1
+ARG S6_OVERLAY_VERSION=2.1.0.0
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/debian/armv7/Dockerfile
+++ b/debian/armv7/Dockerfile
@@ -17,7 +17,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=2.0.0.1
+ARG S6_OVERLAY_VERSION=2.1.0.0
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/debian/i386/Dockerfile
+++ b/debian/i386/Dockerfile
@@ -13,7 +13,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=2.0.0.1
+ARG S6_OVERLAY_VERSION=2.1.0.0
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/raspbian/Dockerfile
+++ b/raspbian/Dockerfile
@@ -17,7 +17,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=2.0.0.1
+ARG S6_OVERLAY_VERSION=2.1.0.0
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/ubuntu/aarch64/Dockerfile
+++ b/ubuntu/aarch64/Dockerfile
@@ -16,7 +16,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=2.0.0.1
+ARG S6_OVERLAY_VERSION=2.1.0.0
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/ubuntu/amd64/Dockerfile
+++ b/ubuntu/amd64/Dockerfile
@@ -13,7 +13,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=2.0.0.1
+ARG S6_OVERLAY_VERSION=2.1.0.0
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/ubuntu/armv7/Dockerfile
+++ b/ubuntu/armv7/Dockerfile
@@ -16,7 +16,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=2.0.0.1
+ARG S6_OVERLAY_VERSION=2.1.0.0
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/ubuntu/i386/Dockerfile
+++ b/ubuntu/i386/Dockerfile
@@ -13,7 +13,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Base system
 ARG BASHIO_VERSION=0.9.0
-ARG S6_OVERLAY_VERSION=2.0.0.1
+ARG S6_OVERLAY_VERSION=2.1.0.0
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \


### PR DESCRIPTION
Release notes:

https://github.com/just-containers/s6-overlay/releases/tag/v2.1.0.0
