### PR TITLE
Apply patch for Python 3.8 for sendfile for files over 2GB

### DIFF
--- a/python/3.8/sendfile_overflow.patch
+++ b/python/3.8/sendfile_overflow.patch
@@ -1,0 +1,44 @@
+diff --git a/Lib/shutil.py b/Lib/shutil.py
+index 5c1255a6713de..1e89256cc3444 100644
+--- a/Lib/shutil.py
++++ b/Lib/shutil.py
+@@ -135,9 +135,13 @@ def _fastcopy_sendfile(fsrc, fdst):
+     # should not make any difference, also in case the file content
+     # changes while being copied.
+     try:
+-        blocksize = max(os.fstat(infd).st_size, 2 ** 23)  # min 8MB
+-    except Exception:
+-        blocksize = 2 ** 27  # 128MB
++        blocksize = max(os.fstat(infd).st_size, 2 ** 23)  # min 8MiB
++    except OSError:
++        blocksize = 2 ** 27  # 128MiB
++    # On 32-bit architectures truncate to 1GiB to avoid OverflowError,
++    # see bpo-38319.
++    if sys.maxsize < 2 ** 32:
++        blocksize = min(blocksize, 2 ** 30)
+ 
+     offset = 0
+     while True:
+diff --git a/Lib/socket.py b/Lib/socket.py
+index af2ed0e76a498..813f4ef5c3e1f 100644
+--- a/Lib/socket.py
++++ b/Lib/socket.py
+@@ -355,8 +355,8 @@ def _sendfile_use_sendfile(self, file, offset=0, count=None):
+                 raise _GiveupOnSendfile(err)  # not a regular file
+             if not fsize:
+                 return 0  # empty file
+-            blocksize = fsize if not count else count
+-
++            # Truncate to 1GiB to avoid OverflowError, see bpo-38319.
++            blocksize = min(count or fsize, 2 ** 30)
+             timeout = self.gettimeout()
+             if timeout == 0:
+                 raise ValueError("non-blocking sockets are not supported")
+diff --git a/Misc/NEWS.d/next/Library/2019-09-30-22-06-33.bpo-38319.5QjiDa.rst b/Misc/NEWS.d/next/Library/2019-09-30-22-06-33.bpo-38319.5QjiDa.rst
+new file mode 100644
+index 0000000000000..376a9e459de27
+--- /dev/null
++++ b/Misc/NEWS.d/next/Library/2019-09-30-22-06-33.bpo-38319.5QjiDa.rst
+@@ -0,0 +1,2 @@
++sendfile() used in socket and shutil modules was raising OverflowError for
++files >= 2GiB on 32-bit architectures.  (patch by Giampaolo Rodola)


### PR DESCRIPTION
Applies patch for <https://bugs.python.org/issue38319>

Fixes https://github.com/home-assistant/supervisor/issues/2047

```
20-10-27 14:35:48 INFO (MainThread) [supervisor.api.snapshots] Downloading snapshot 91fd5e56
20-10-27 14:35:48 ERROR (MainThread) [aiohttp.server] Unhandled exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/aiohttp/web_protocol.py", line 485, in start
    resp, reset = await task
  File "/usr/local/lib/python3.8/site-packages/aiohttp/web_protocol.py", line 440, in _handle_request
    reset = await self.finish_response(request, resp, start_time)
  File "/usr/local/lib/python3.8/site-packages/aiohttp/web_protocol.py", line 591, in finish_response
    await prepare_meth(request)
  File "/usr/local/lib/python3.8/site-packages/aiohttp/web_fileresponse.py", line 241, in prepare
    return await self._sendfile(request, fobj, offset, count)
  File "/usr/local/lib/python3.8/site-packages/aiohttp/web_fileresponse.py", line 96, in _sendfile
    await loop.sendfile(transport, fobj, offset, count)
  File "/usr/local/lib/python3.8/asyncio/base_events.py", line 1120, in sendfile
    return await self._sendfile_native(transport, file,
  File "/usr/local/lib/python3.8/asyncio/selector_events.py", line 578, in _sendfile_native
    return await self.sock_sendfile(transp._sock, file, offset, count,
  File "/usr/local/lib/python3.8/asyncio/base_events.py", line 838, in sock_sendfile
    return await self._sock_sendfile_native(sock, file,
  File "/usr/local/lib/python3.8/asyncio/unix_events.py", line 351, in _sock_sendfile_native
    return await fut
  File "/usr/local/lib/python3.8/asyncio/unix_events.py", line 373, in _sock_sendfile_native_impl
    sent = os.sendfile(fd, fileno, offset, blocksize)
OverflowError: Python int too large to convert to C ssize_t
```