### PR TITLE
Patch asyncio.unix_events for bpo-38319

### DIFF
--- a/python/3.8/asynctio_unix_events.patch
+++ b/python/3.8/asynctio_unix_events.patch
@@ -1,0 +1,16 @@
+diff --git a/Lib/asyncio/unix_events.py b/Lib/asyncio/unix_events.py
+index 1ff8c427da..0e8eb719ed 100644
+--- a/Lib/asyncio/unix_events.py
++++ b/Lib/asyncio/unix_events.py
+@@ -369,6 +369,11 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
+                 fut.set_result(total_sent)
+                 return
+ 
++        # On 32-bit architectures truncate to 1GiB to avoid OverflowError,
++        # see bpo-38319.
++        if sys.maxsize < 2 ** 32:
++            blocksize = min(blocksize, 2 ** 30)
++
+         try:
+             sent = os.sendfile(fd, fileno, offset, blocksize)
+         except (BlockingIOError, InterruptedError):

--- a/python/3.9/asynctio_unix_events.patch
+++ b/python/3.9/asynctio_unix_events.patch
@@ -1,0 +1,16 @@
+diff --git a/Lib/asyncio/unix_events.py b/Lib/asyncio/unix_events.py
+index f34a5b4b44..b1d0f1e61e 100644
+--- a/Lib/asyncio/unix_events.py
++++ b/Lib/asyncio/unix_events.py
+@@ -369,6 +369,11 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
+                 fut.set_result(total_sent)
+                 return
+ 
++        # On 32-bit architectures truncate to 1GiB to avoid OverflowError,
++        # see bpo-38319.
++        if sys.maxsize < 2 ** 32:
++            blocksize = min(blocksize, 2 ** 30)
++
+         try:
+             sent = os.sendfile(fd, fileno, offset, blocksize)
+         except (BlockingIOError, InterruptedError):


### PR DESCRIPTION
Since the patches that were added to <https://github.com/home-assistant/docker-base/pull/95> already existed in 3.8.6, that failed...

So let's try that again (with patching what actually breaks for us), this time it's also patched for 3.9 and has been locally verified.
The reason is the same as stated in #95