### PR TITLE
Add tzdata package to prevent dependency to overwrite custom build

### DIFF
--- a/alpine/armhf/Dockerfile
+++ b/alpine/armhf/Dockerfile
@@ -28,10 +28,11 @@ RUN \
     set -x \
     && apk add --no-cache \
         bash \
-        jq \
+        bind-tools \
         ca-certificates \
         curl \
-        bind-tools \
+        jq \
+        tzdata \
     \
     && apk add --no-cache --virtual .build-deps \
         build-base \

--- a/alpine/armv7/Dockerfile
+++ b/alpine/armv7/Dockerfile
@@ -28,10 +28,11 @@ RUN \
     set -x \
     && apk add --no-cache \
         bash \
-        jq \
+        bind-tools \
         ca-certificates \
         curl \
-        bind-tools \
+        jq \
+        tzdata \
     \
     && apk add --no-cache --virtual .build-deps \
         build-base \

--- a/alpine/i386/Dockerfile
+++ b/alpine/i386/Dockerfile
@@ -25,10 +25,11 @@ RUN \
     set -x \
     && apk add --no-cache \
         bash \
-        jq \
+        bind-tools \
         ca-certificates \
         curl \
-        bind-tools \
+        jq \
+        tzdata \
     \
     && apk add --no-cache --virtual .build-deps \
         build-base \


### PR DESCRIPTION
Re-adds `tzdata` package to 32 bits builds.

It does get overwritten in the build, but this ensures the package manager registers it.
This prevents our custom build to be overwritten by a tzdata being pulled in as a dependency in later build steps.