### PR TITLE
Add version pining to tzdata to bust Docker caching

### DIFF
--- a/alpine/aarch64/Dockerfile
+++ b/alpine/aarch64/Dockerfile
@@ -27,11 +27,11 @@ RUN \
     set -x \
     && apk add --no-cache \
         bash \
-        jq \
-        tzdata \
+        bind-tools \
         ca-certificates \
         curl \
-        bind-tools \
+        jq \
+        "tzdata>=2020c-r1" \
     \
     && apk add --no-cache --virtual .build-deps \
         build-base \

--- a/alpine/amd64/Dockerfile
+++ b/alpine/amd64/Dockerfile
@@ -24,11 +24,11 @@ RUN \
     set -x \
     && apk add --no-cache \
         bash \
-        jq \
-        tzdata \
+        bind-tools \
         ca-certificates \
         curl \
-        bind-tools \
+        jq \
+        "tzdata>=2020c-r1" \
     \
     && apk add --no-cache --virtual .build-deps \
         build-base \

--- a/alpine/armhf/Dockerfile
+++ b/alpine/armhf/Dockerfile
@@ -31,7 +31,7 @@ RUN \
         ca-certificates \
         curl \
         jq \
-        tzdata \
+        "tzdata>=2020c-r1" \
     \
     && apk add --no-cache --virtual .build-deps \
         build-base \

--- a/alpine/armv7/Dockerfile
+++ b/alpine/armv7/Dockerfile
@@ -31,7 +31,7 @@ RUN \
         ca-certificates \
         curl \
         jq \
-        tzdata \
+        "tzdata>=2020c-r1" \
     \
     && apk add --no-cache --virtual .build-deps \
         build-base \

--- a/alpine/i386/Dockerfile
+++ b/alpine/i386/Dockerfile
@@ -28,7 +28,7 @@ RUN \
         ca-certificates \
         curl \
         jq \
-        tzdata \
+        "tzdata>=2020c-r1" \
     \
     && apk add --no-cache --virtual .build-deps \
         build-base \


### PR DESCRIPTION
We've been bitten by our own efficient build processes that use Docker layer caching.

Since the Dockerfiles for amd64/aarch64 didn't change, the previous effort to update tzdata didn't have any effect.

This PR adds version pinning to tzdata (in terms of pinning a minimum version). This busts the cache for all.