### PR TITLE
Replace jemalloc with mimalloc

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ We support version that are not EOL: https://alpinelinux.org/releases/
 
 ### Jemalloc
 
-We support on our platforms jemalloc. On application which you want enable it, set as envoriement `LD_PRELOAD="/usr/lib/libmimalloc.so"` on your Dockerfile or before you start the application.
+We support on our platforms jemalloc. On application which you want enable it, set as envoriement `LD_PRELOAD="/usr/local/lib/libmimalloc.so"` on your Dockerfile or before you start the application.
 
 ### Python images
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ We support version that are not EOL: https://alpinelinux.org/releases/
 
 ### Jemalloc
 
-We support on our platforms jemalloc. On application which you want enable it, set as envoriement `LD_PRELOAD="/usr/local/lib/libjemalloc.so.2"` on your Dockerfile or before you start the application.
+We support on our platforms jemalloc. On application which you want enable it, set as envoriement `LD_PRELOAD="/usr/lib/libmimalloc.so"` on your Dockerfile or before you start the application.
 
 ### Python images
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -55,7 +55,8 @@ RUN \
     && mkdir -p /etc/fix-attrs.d \
     && mkdir -p /etc/services.d \
     \
-    && git clone --depth 1 -b v${MIMALLOC_VERSION} "https://github.com/microsoft/mimalloc" /usr/src/mimalloc \
+    && git clone --depth 1 -b v${MIMALLOC_VERSION} \
+        "https://github.com/microsoft/mimalloc" /usr/src/mimalloc \
     && mkdir -p /usr/src/mimalloc/build \
     && cd /usr/src/mimalloc/build \
     && cmake .. \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -56,7 +56,8 @@ RUN \
     && mkdir -p /etc/services.d \
     \
     && git clone --depth 1 -b v${MIMALLOC_VERSION} "https://github.com/microsoft/mimalloc" /usr/src/mimalloc \
-    && mkdir -p /usr/src/mimalloc/release \
+    && mkdir -p /usr/src/mimalloc/build \
+    && cd /usr/src/mimalloc/build \
     && cmake .. \
     && make -j "$(nproc)" \
     && make install \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -56,8 +56,8 @@ RUN \
     && mkdir -p /etc/services.d \
     \
     && git clone --depth 1 -b v${MIMALLOC_VERSION} "https://github.com/microsoft/mimalloc" /usr/src/mimalloc \
-    && mkdir -p /usr/src/mimalloc/out/release \
-    && cmake ../.. \
+    && mkdir -p /usr/src/mimalloc/release \
+    && cmake .. \
     && make -j "$(nproc)" \
     && make install \
     \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -21,7 +21,7 @@ ARG \
     BASHIO_VERSION \
     TEMPIO_VERSION \
     S6_OVERLAY_VERSION \
-    JEMALLOC_VERSION
+    MIMALLOC_VERSION
 
 # Base system
 WORKDIR /usr/src
@@ -39,6 +39,8 @@ RUN \
     \
     && apk add --no-cache --virtual .build-deps \
         build-base \
+        cmake \
+        git \
     \
     && if [ "${BUILD_ARCH}" = "armv7" ]; then \
             export S6_ARCH="arm"; \
@@ -53,11 +55,10 @@ RUN \
     && mkdir -p /etc/fix-attrs.d \
     && mkdir -p /etc/services.d \
     \
-    && curl -L -f -s "https://github.com/jemalloc/jemalloc/releases/download/${JEMALLOC_VERSION}/jemalloc-${JEMALLOC_VERSION}.tar.bz2" \
-        | tar -xjf - -C /usr/src \
-    && cd /usr/src/jemalloc-${JEMALLOC_VERSION} \
-    && ./configure \
-    && make \
+    && git clone --depth 1 -b v${MIMALLOC_VERSION} "https://github.com/microsoft/mimalloc" /usr/src/mimalloc \
+    && mkdir -p /usr/src/mimalloc/out/release \
+    && cmake ../.. \
+    && make -j "$(nproc)" \
     && make install \
     \
     && mkdir -p /usr/src/bashio \

--- a/alpine/build.json
+++ b/alpine/build.json
@@ -12,7 +12,7 @@
         "BASHIO_VERSION": "0.13.0",
         "TEMPIO_VERSION": "2021.01.0",
         "S6_OVERLAY_VERSION": "2.1.0.2",
-        "JEMALLOC_VERSION": "5.2.1"
+        "MIMALLOC_VERSION": "1.7.1"
     },
     "labels": {
         "io.hass.base.name": "alpine"

--- a/python/3.7/Dockerfile
+++ b/python/3.7/Dockerfile
@@ -83,7 +83,7 @@ RUN set -ex \
         --without-ensurepip \
     && make -j "$(nproc)" \
         LDFLAGS="-Wl,--strip-all" \
-        CFLAGS="-fno-semantic-interposition -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -ljemalloc" \
+        CFLAGS="-fno-semantic-interposition -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free" \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
         EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \

--- a/python/3.8/Dockerfile
+++ b/python/3.8/Dockerfile
@@ -83,7 +83,7 @@ RUN set -ex \
         --without-ensurepip \
     && make -j "$(nproc)" \
         LDFLAGS="-Wl,--strip-all" \
-        CFLAGS="-fno-semantic-interposition -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -ljemalloc" \
+        CFLAGS="-fno-semantic-interposition -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free" \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
         EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \

--- a/python/3.9/Dockerfile
+++ b/python/3.9/Dockerfile
@@ -84,7 +84,7 @@ RUN set -ex \
         --without-ensurepip \
     && make -j "$(nproc)" \
         LDFLAGS="-Wl,--strip-all" \
-        CFLAGS="-fno-semantic-interposition -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -ljemalloc" \
+        CFLAGS="-fno-semantic-interposition -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free" \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
         EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \


### PR DESCRIPTION
Switch jemalloc to mimalloc

https://github.com/microsoft/mimalloc

The current stable 1.7.x of mimalloc is similar to jemalloc, sometimes a bit faster but that is only shown on labs and not real-world. Also, the memory handling looks more stable. Next release 2.0.x will make mimalloc over the place better as jemalloc. Also, jemalloc is active in development but the latest release was in 2019, and after that, there are only custom builds.

I say we should do the cut now and having somethings more feature approved. It's absolut true that this today is just a small improvement, but then they will be greater and greater over time.