### PR TITLE
Update s6-overlay to 2.2.0.3

### DIFF
--- a/alpine/build.json
+++ b/alpine/build.json
@@ -11,7 +11,7 @@
     "args": {
         "BASHIO_VERSION": "0.13.0",
         "TEMPIO_VERSION": "2021.01.0",
-        "S6_OVERLAY_VERSION": "2.1.0.2",
+        "S6_OVERLAY_VERSION": "2.2.0.3",
         "JEMALLOC_VERSION": "5.2.1"
     },
     "labels": {

--- a/debian/build.json
+++ b/debian/build.json
@@ -11,7 +11,7 @@
     "args": {
         "BASHIO_VERSION": "0.13.0",
         "TEMPIO_VERSION": "2021.01.0",
-        "S6_OVERLAY_VERSION": "2.1.0.2"
+        "S6_OVERLAY_VERSION": "2.2.0.3"
     },
     "labels": {
         "io.hass.base.name": "debian",

--- a/raspbian/build.json
+++ b/raspbian/build.json
@@ -7,7 +7,7 @@
     "args": {
         "BASHIO_VERSION": "0.13.0",
         "TEMPIO_VERSION": "2021.01.0",
-        "S6_OVERLAY_VERSION": "2.1.0.2"
+        "S6_OVERLAY_VERSION": "2.2.0.3"
     },
     "labels": {
         "io.hass.base.name": "raspbian",

--- a/ubuntu/build.json
+++ b/ubuntu/build.json
@@ -9,7 +9,7 @@
     "args": {
         "BASHIO_VERSION": "0.13.0",
         "TEMPIO_VERSION": "2021.01.0",
-        "S6_OVERLAY_VERSION": "2.1.0.2"
+        "S6_OVERLAY_VERSION": "2.2.0.3"
     },
     "labels": {
         "io.hass.base.name": "ubuntu",


### PR DESCRIPTION
My Docker setup is using user namespaces, but I have it disabled with --userns=host for Home Assistant to use host networking and access usb devices. This worked fine up until v.0.116.4 (no idea why). 

I'm was getting these error logs:
```
s6-overlay-preinit: fatal: unable to chown /var/run/s6: Operation not permitted
s6-overlay-preinit: fatal: unable to chown /var/run/s6: Operation not permitted
```

I found just-containers/s6-overlay#309, which looks like it's this issue. This was fixed in s6-overlay v2.2.0.0. 