### PR TITLE
Update jemalloc 254b011

### DIFF
--- a/alpine/build.yaml
+++ b/alpine/build.yaml
@@ -12,7 +12,7 @@ args:
   BASHIO_VERSION: 0.14.3
   TEMPIO_VERSION: 2021.09.0
   S6_OVERLAY_VERSION: 2.1.0.2
-  JEMALLOC_VERSION: 5.2.1
+  JEMALLOC_VERSION: 254b011915c0c68549beb7a91be02cf56d81fa32
 labels:
   io.hass.base.name: alpine
   org.opencontainers.image.source: https://github.com/home-assistant/docker-base


### PR DESCRIPTION
That is the 5.3rc - but jemalloc started to provide productive stable commit hash instead of release. I guess we would go in that direction and use it. I've tested the commit against pyperformance and it passes all tests unlike 5.2.1 which we use today. So it's even more stable as what we run today