### PR TITLE
Update S6-Overlay to 3.1.1.0

### DIFF
--- a/alpine/build.yaml
+++ b/alpine/build.yaml
@@ -11,7 +11,7 @@ codenotary:
 args:
   BASHIO_VERSION: 0.14.3
   TEMPIO_VERSION: 2021.09.0
-  S6_OVERLAY_VERSION: 3.1.0.1
+  S6_OVERLAY_VERSION: 3.1.1.0
   JEMALLOC_VERSION: 5.3.0
 labels:
   io.hass.base.name: alpine

--- a/debian/build.yaml
+++ b/debian/build.yaml
@@ -11,7 +11,7 @@ codenotary:
 args:
   BASHIO_VERSION: 0.14.3
   TEMPIO_VERSION: 2021.09.0
-  S6_OVERLAY_VERSION: 3.1.0.1
+  S6_OVERLAY_VERSION: 3.1.1.0
 labels:
   io.hass.base.name: debian
   org.opencontainers.image.source: https://github.com/home-assistant/docker-base

--- a/raspbian/build.yaml
+++ b/raspbian/build.yaml
@@ -7,7 +7,7 @@ codenotary:
 args:
   BASHIO_VERSION: 0.14.3
   TEMPIO_VERSION: 2021.09.0
-  S6_OVERLAY_VERSION: 3.1.0.1
+  S6_OVERLAY_VERSION: 3.1.1.0
 labels:
   io.hass.base.name: raspbian
   org.opencontainers.image.source: https://github.com/home-assistant/docker-base

--- a/ubuntu/build.yaml
+++ b/ubuntu/build.yaml
@@ -9,7 +9,7 @@ codenotary:
 args:
   BASHIO_VERSION: 0.14.3
   TEMPIO_VERSION: 2021.09.0
-  S6_OVERLAY_VERSION: 3.1.0.1
+  S6_OVERLAY_VERSION: 3.1.1.0
 labels:
   io.hass.base.name: ubuntu
   org.opencontainers.image.source: https://github.com/home-assistant/docker-base


### PR DESCRIPTION
Small fixes and updates, see:

<https://github.com/just-containers/s6-overlay/compare/v3.1.0.1...v3.1.1.0>