### PR TITLE
Fix intermittent `unable to s6_svstatus_read` error

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -12,7 +12,8 @@ ENV \
     LANG="C.UTF-8" \
     S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
     S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
-    S6_CMD_WAIT_FOR_SERVICES=1
+    S6_CMD_WAIT_FOR_SERVICES=1 \
+    S6_SERVICES_READYTIME=50
 
 # Set shell
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -14,7 +14,8 @@ ENV \
     CURL_CA_BUNDLE="/etc/ssl/certs/ca-certificates.crt" \
     S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
     S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
-    S6_CMD_WAIT_FOR_SERVICES=1
+    S6_CMD_WAIT_FOR_SERVICES=1 \
+    S6_SERVICES_READYTIME=50
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/raspbian/Dockerfile
+++ b/raspbian/Dockerfile
@@ -10,7 +10,8 @@ ENV \
     CURL_CA_BUNDLE="/etc/ssl/certs/ca-certificates.crt" \
     S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
     S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
-    S6_CMD_WAIT_FOR_SERVICES=1
+    S6_CMD_WAIT_FOR_SERVICES=1 \
+    S6_SERVICES_READYTIME=50
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -12,7 +12,8 @@ ENV \
     DEBIAN_FRONTEND="noninteractive" \
     S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
     S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
-    S6_CMD_WAIT_FOR_SERVICES=1
+    S6_CMD_WAIT_FOR_SERVICES=1 \
+    S6_SERVICES_READYTIME=50
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
- Refs https://github.com/home-assistant/core/issues/79976

I noticed this issue in both HA core and any addon, intermittently, so I believe it's safe to add this by default in the base images.

The default value is 5 (milliseconds), and I increased to 50 milliseconds. This should be more than enough to iron out the issue even in the worst scenario, while the additional 45 ms makes absolutely no difference for the HA use case (in my opinion).

@frenck I plan to send the same PR for the community addons base images as well, as I have noticed this issue to happen in the Asterisk addon, which extends from the Debian community addon base.