### PR TITLE
Revert "Bump python patch version to 3.10.10"

### DIFF
--- a/python/3.10/build.yaml
+++ b/python/3.10/build.yaml
@@ -10,7 +10,7 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  PYTHON_VERSION: 3.10.10
+  PYTHON_VERSION: 3.10.7
   PIP_VERSION: 23.0.0
   GPG_KEY: A035C8C19219BA821ECEA86B64E628F8D684696D
 labels:


### PR DESCRIPTION
Reverts home-assistant/docker-base#197

CC: @bdraco 

We have issues with dbus-fast:
```
AttributeError: 'bool' object has no attribute 'signature'
Exception ignored in: 'dbus_fast._private.marshaller.Marshaller._write_variant'
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/dbus_fast/aio/message_bus.py", line 103, in buffer_message
    msg._marshall(self.negotiate_unix_fd),
AttributeError: 'bool' object has no attribute 'signature'
23-02-15 09:52:51 ERROR (MainThread) [root] add match request failed. match="type='signal',sender=io.hass.os,interface=org.freedesktop.DBus.Properties,path=/io/hass/os", [Errno 32] Broken pipe
```