### PR TITLE
Drop Alpine 3.13

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson(needs.init.outputs.architectures_alpine) }}
-        version: ["3.13", "3.14", "3.15", "3.16"] 
+        version: ["3.14", "3.15", "3.16"] 
     steps:
     - name: Checkout the repository
       uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ We support version that are not EOL: https://alpinelinux.org/releases/
 
 | Image | OS | Tags | latest |
 |-------|----|------|--------|
-| armhf-base | Alpine | 3.13 3.14, 3.15, 3.16 | 3.16 |
-| armv7-base | Alpine | 3.13 3.14, 3.15, 3.16 | 3.16 |
-| aarch64-base | Alpine | 3.13 3.14, 3.15, 3.16 | 3.16 |
-| amd64-base | Alpine | 3.13 3.14, 3.15, 3.16 | 3.16 |
-| i386-base | Alpine | 3.13 3.14, 3.15, 3.16 | 3.16 |
+| armhf-base | Alpine | 3.14, 3.15, 3.16 | 3.16 |
+| armv7-base | Alpine | 3.14, 3.15, 3.16 | 3.16 |
+| aarch64-base | Alpine | 3.14, 3.15, 3.16 | 3.16 |
+| amd64-base | Alpine | 3.14, 3.15, 3.16 | 3.16 |
+| i386-base | Alpine | 3.14, 3.15, 3.16 | 3.16 |
 
 ### jemalloc
 


### PR DESCRIPTION
Alpine 3.13 became end-of-life in November 2022.

<https://alpinelinux.org/releases/>