### PR TITLE
Update pip to 23.1.1

### DIFF
--- a/python/3.10/build.yaml
+++ b/python/3.10/build.yaml
@@ -11,7 +11,7 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   PYTHON_VERSION: 3.10.11
-  PIP_VERSION: 23.1
+  PIP_VERSION: 23.1.1
   GPG_KEY: A035C8C19219BA821ECEA86B64E628F8D684696D
 labels:
   io.hass.base.name: python

--- a/python/3.11/build.yaml
+++ b/python/3.11/build.yaml
@@ -11,7 +11,7 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   PYTHON_VERSION: 3.11.3
-  PIP_VERSION: 23.1
+  PIP_VERSION: 23.1.1
   GPG_KEY: A035C8C19219BA821ECEA86B64E628F8D684696D
 labels:
   io.hass.base.name: python

--- a/python/3.9/build.yaml
+++ b/python/3.9/build.yaml
@@ -11,7 +11,7 @@ codenotary:
   base_image: notary@home-assistant.io
 args:
   PYTHON_VERSION: 3.9.16
-  PIP_VERSION: 23.1
+  PIP_VERSION: 23.1.1
   GPG_KEY: E3FF2839C048B25C084DEBE9B26995E310250568
 labels:
   io.hass.base.name: python


### PR DESCRIPTION
Updates `pip` to 23.1.1
Release notes: <https://pip.pypa.io/en/stable/news/#v23-1-1>