### PR TITLE
Add Alpine Linux 3.18

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   BUILD_TYPE: base
-  ALPINE_LATEST: "3.17"
+  ALPINE_LATEST: "3.18"
   DEBIAN_LATEST: "bullseye"
   UBUNTU_LATEST: "20.4"
   RASPBIAN_LATEST: "bullseye"
@@ -67,7 +67,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson(needs.init.outputs.architectures_alpine) }}
-        version: ["3.14", "3.15", "3.16", "3.17"] 
+        version: ["3.14", "3.15", "3.16", "3.17", "3.18"]
     steps:
     - name: Checkout the repository
       uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ We support version that are not EOL: https://alpinelinux.org/releases/
 
 | Image | OS | Tags | latest |
 |-------|----|------|--------|
-| armhf-base | Alpine | 3.14, 3.15, 3.16, 3.17 | 3.17 |
-| armv7-base | Alpine | 3.14, 3.15, 3.16, 3.17 | 3.17 |
-| aarch64-base | Alpine | 3.14, 3.15, 3.16, 3.17 | 3.17 |
-| amd64-base | Alpine | 3.14, 3.15, 3.16, 3.17 | 3.17 |
-| i386-base | Alpine | 3.14, 3.15, 3.16, 3.17 | 3.17 |
+| armhf-base | Alpine | 3.14, 3.15, 3.16, 3.17 3.18 | 3.18 |
+| armv7-base | Alpine | 3.14, 3.15, 3.16, 3.17 3.18 | 3.18 |
+| aarch64-base | Alpine | 3.14, 3.15, 3.16, 3.17 3.18 | 3.18 |
+| amd64-base | Alpine | 3.14, 3.15, 3.16, 3.17 3.18 | 3.18 |
+| i386-base | Alpine | 3.14, 3.15, 3.16, 3.17 3.18 | 3.18 |
 
 ### jemalloc
 


### PR DESCRIPTION
Add support for Alpine Linux 3.18

https://alpinelinux.org/posts/Alpine-3.18.0-released.html

(I'll create a separate PR to drop 3.14)