### PR TITLE
Drop Alpine 3.14

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson(needs.init.outputs.architectures_alpine) }}
-        version: ["3.14", "3.15", "3.16", "3.17", "3.18"]
+        version: ["3.15", "3.16", "3.17", "3.18"]
     steps:
     - name: Checkout the repository
       uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ We support version that are not EOL: https://alpinelinux.org/releases/
 
 | Image | OS | Tags | latest |
 |-------|----|------|--------|
-| armhf-base | Alpine | 3.14, 3.15, 3.16, 3.17 3.18 | 3.18 |
-| armv7-base | Alpine | 3.14, 3.15, 3.16, 3.17 3.18 | 3.18 |
-| aarch64-base | Alpine | 3.14, 3.15, 3.16, 3.17 3.18 | 3.18 |
-| amd64-base | Alpine | 3.14, 3.15, 3.16, 3.17 3.18 | 3.18 |
-| i386-base | Alpine | 3.14, 3.15, 3.16, 3.17 3.18 | 3.18 |
+| armhf-base | Alpine | 3.15, 3.16, 3.17 3.18 | 3.18 |
+| armv7-base | Alpine | 3.15, 3.16, 3.17 3.18 | 3.18 |
+| aarch64-base | Alpine | 3.15, 3.16, 3.17 3.18 | 3.18 |
+| amd64-base | Alpine | 3.15, 3.16, 3.17 3.18 | 3.18 |
+| i386-base | Alpine | 3.15, 3.16, 3.17 3.18 | 3.18 |
 
 ### jemalloc
 


### PR DESCRIPTION
This PR drops Alpine 3.14, it became EOL on 1 May.

https://www.alpinelinux.org/releases/