### PR TITLE
Python: Drop Alpine 3.15, add Alpine 3.18

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -12,7 +12,7 @@ env:
   DEBIAN_LATEST: "bullseye"
   UBUNTU_LATEST: "20.4"
   RASPBIAN_LATEST: "bullseye"
-  PYTHON_LATEST: "3.10"
+  PYTHON_LATEST: "3.11"
 
 jobs:
   init:

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -261,7 +261,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson(needs.init.outputs.architectures_alpine) }}
-        version: ["3.15", "3.16", "3.17"]
+        version: ["3.16", "3.17", "3.18"]
         python: ["3.9", "3.10", "3.11"]
     steps:
     - name: Checkout the repository

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ We support the latest 3 release with the latest 3 Alpine version.
 
 | Image | OS | Tags | latest |
 |-------|----|------|--------|
-| armhf-base-python | Alpine | 3.9, 3.10, 3.11, 3.9-alpine3.16, 3.9-alpine3.17, 3.9-alpine3.18, 3.10-alpine3.16, 3.10-alpine3.17, 3.10-alpine3.18, 3.11-alpine3.16, 3.11-alpine3.17, 3.11-alpine3.18 | 3.10-alpine3.18 |
-| armv7-base-python | Alpine | 3.9, 3.10, 3.11, 3.9-alpine3.16, 3.9-alpine3.17, 3.9-alpine3.18, 3.10-alpine3.16, 3.10-alpine3.17, 3.10-alpine3.18, 3.11-alpine3.16, 3.11-alpine3.17, 3.11-alpine3.18 | 3.10-alpine3.18 |
-| aarch64-base-python | Alpine | 3.9, 3.10, 3.11, 3.9-alpine3.16, 3.9-alpine3.17, 3.9-alpine3.18, 3.10-alpine3.16, 3.10-alpine3.17, 3.10-alpine3.18, 3.11-alpine3.16, 3.11-alpine3.17, 3.11-alpine3.18 | 3.10-alpine3.18 |
-| amd64-base-python | Alpine | 3.9, 3.10, 3.11, 3.9-alpine3.16, 3.9-alpine3.17, 3.9-alpine3.18, 3.10-alpine3.16, 3.10-alpine3.17, 3.10-alpine3.18, 3.11-alpine3.16, 3.11-alpine3.17, 3.11-alpine3.18 | 3.10-alpine3.18 |
-| i386-base-python | Alpine | 3.9, 3.10, 3.11, 3.9-alpine3.16, 3.9-alpine3.17, 3.9-alpine3.18, 3.10-alpine3.16, 3.10-alpine3.17, 3.10-alpine3.18, 3.11-alpine3.16, 3.11-alpine3.17, 3.11-alpine3.18 | 3.10-alpine3.18 |
+| armhf-base-python | Alpine | 3.9, 3.10, 3.11, 3.9-alpine3.16, 3.9-alpine3.17, 3.9-alpine3.18, 3.10-alpine3.16, 3.10-alpine3.17, 3.10-alpine3.18, 3.11-alpine3.16, 3.11-alpine3.17, 3.11-alpine3.18 | 3.11-alpine3.18 |
+| armv7-base-python | Alpine | 3.9, 3.10, 3.11, 3.9-alpine3.16, 3.9-alpine3.17, 3.9-alpine3.18, 3.10-alpine3.16, 3.10-alpine3.17, 3.10-alpine3.18, 3.11-alpine3.16, 3.11-alpine3.17, 3.11-alpine3.18 | 3.11-alpine3.18 |
+| aarch64-base-python | Alpine | 3.9, 3.10, 3.11, 3.9-alpine3.16, 3.9-alpine3.17, 3.9-alpine3.18, 3.10-alpine3.16, 3.10-alpine3.17, 3.10-alpine3.18, 3.11-alpine3.16, 3.11-alpine3.17, 3.11-alpine3.18 | 3.11-alpine3.18 |
+| amd64-base-python | Alpine | 3.9, 3.10, 3.11, 3.9-alpine3.16, 3.9-alpine3.17, 3.9-alpine3.18, 3.10-alpine3.16, 3.10-alpine3.17, 3.10-alpine3.18, 3.11-alpine3.16, 3.11-alpine3.17, 3.11-alpine3.18 | 3.11-alpine3.18 |
+| i386-base-python | Alpine | 3.9, 3.10, 3.11, 3.9-alpine3.16, 3.9-alpine3.17, 3.9-alpine3.18, 3.10-alpine3.16, 3.10-alpine3.17, 3.10-alpine3.18, 3.11-alpine3.16, 3.11-alpine3.17, 3.11-alpine3.18 | 3.11-alpine3.18 |
 
 ## Others
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ We support the latest 3 release with the latest 3 Alpine version.
 
 | Image | OS | Tags | latest |
 |-------|----|------|--------|
-| armhf-base-python | Alpine | 3.9, 3.10, 3.11, 3.9-alpine3.15, 3.9-alpine3.16, 3.10-alpine3.14, 3.10-alpine3.15, 3.10-alpine3.16, 3.11-alpine3.14, 3.11-alpine3.15, 3.11-alpine3.16, 3.11-alpine3.17 | 3.10-alpine3.17 |
-| armv7-base-python | Alpine | 3.9, 3.10, 3.11, 3.9-alpine3.15, 3.9-alpine3.16, 3.10-alpine3.14, 3.10-alpine3.15, 3.10-alpine3.16, 3.11-alpine3.14, 3.11-alpine3.15, 3.11-alpine3.16, 3.11-alpine3.17 | 3.10-alpine3.17 |
-| aarch64-base-python | Alpine | 3.9, 3.10, 3.11, 3.9-alpine3.15, 3.9-alpine3.16, 3.10-alpine3.14, 3.10-alpine3.15, 3.10-alpine3.16, 3.11-alpine3.14, 3.11-alpine3.15, 3.11-alpine3.16, 3.11-alpine3.17 | 3.10-alpine3.17 |
-| amd64-base-python | Alpine | 3.9, 3.10, 3.11, 3.9-alpine3.15, 3.9-alpine3.16, 3.10-alpine3.14, 3.10-alpine3.15, 3.10-alpine3.16, 3.11-alpine3.14, 3.11-alpine3.15, 3.11-alpine3.16, 3.11-alpine3.17 | 3.10-alpine3.17 |
-| i386-base-python | Alpine | 3.9, 3.10, 3.11, 3.9-alpine3.15, 3.9-alpine3.16, 3.10-alpine3.14, 3.10-alpine3.15, 3.10-alpine3.16, 3.11-alpine3.14, 3.11-alpine3.15, 3.11-alpine3.16, 3.11-alpine3.17 | 3.10-alpine3.17 |
+| armhf-base-python | Alpine | 3.9, 3.10, 3.11, 3.9-alpine3.16, 3.9-alpine3.17, 3.9-alpine3.18, 3.10-alpine3.16, 3.10-alpine3.17, 3.10-alpine3.18, 3.11-alpine3.16, 3.11-alpine3.17, 3.11-alpine3.18 | 3.10-alpine3.18 |
+| armv7-base-python | Alpine | 3.9, 3.10, 3.11, 3.9-alpine3.16, 3.9-alpine3.17, 3.9-alpine3.18, 3.10-alpine3.16, 3.10-alpine3.17, 3.10-alpine3.18, 3.11-alpine3.16, 3.11-alpine3.17, 3.11-alpine3.18 | 3.10-alpine3.18 |
+| aarch64-base-python | Alpine | 3.9, 3.10, 3.11, 3.9-alpine3.16, 3.9-alpine3.17, 3.9-alpine3.18, 3.10-alpine3.16, 3.10-alpine3.17, 3.10-alpine3.18, 3.11-alpine3.16, 3.11-alpine3.17, 3.11-alpine3.18 | 3.10-alpine3.18 |
+| amd64-base-python | Alpine | 3.9, 3.10, 3.11, 3.9-alpine3.16, 3.9-alpine3.17, 3.9-alpine3.18, 3.10-alpine3.16, 3.10-alpine3.17, 3.10-alpine3.18, 3.11-alpine3.16, 3.11-alpine3.17, 3.11-alpine3.18 | 3.10-alpine3.18 |
+| i386-base-python | Alpine | 3.9, 3.10, 3.11, 3.9-alpine3.16, 3.9-alpine3.17, 3.9-alpine3.18, 3.10-alpine3.16, 3.10-alpine3.17, 3.10-alpine3.18, 3.11-alpine3.16, 3.11-alpine3.17, 3.11-alpine3.18 | 3.10-alpine3.18 |
 
 ## Others
 


### PR DESCRIPTION
We support the latest 3 Alpine versions for our Python image.

This adds Alpine 3.18 and thus drops Alpine 3.15.

After a couple of weeks of testing now, it also sets Python 3.11 as the latest default image.