### PR TITLE
Mark Debian Bookworm as the default stable

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -9,7 +9,7 @@ on:
 env:
   BUILD_TYPE: base
   ALPINE_LATEST: "3.18"
-  DEBIAN_LATEST: "bullseye"
+  DEBIAN_LATEST: "bookworm"
   UBUNTU_LATEST: "20.4"
   RASPBIAN_LATEST: "bullseye"
   PYTHON_LATEST: "3.11"
@@ -25,41 +25,41 @@ jobs:
       architectures_raspbian: ${{ steps.info_raspbian.outputs.architectures }}
       release: ${{ steps.version.outputs.version }}
     steps:
-    - name: Checkout the repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-    - name: Get information Alpine
-      id: info_alpine
-      uses: home-assistant/actions/helpers/info@master
-      with:
-        path: "${{ github.workspace }}/alpine"
+      - name: Get information Alpine
+        id: info_alpine
+        uses: home-assistant/actions/helpers/info@master
+        with:
+          path: "${{ github.workspace }}/alpine"
 
-    - name: Get information Debian
-      id: info_debian
-      uses: home-assistant/actions/helpers/info@master
-      with:
-        path: "${{ github.workspace }}/debian"
+      - name: Get information Debian
+        id: info_debian
+        uses: home-assistant/actions/helpers/info@master
+        with:
+          path: "${{ github.workspace }}/debian"
 
-    - name: Get information Ubuntu
-      id: info_ubuntu
-      uses: home-assistant/actions/helpers/info@master
-      with:
-        path: "${{ github.workspace }}/ubuntu"
+      - name: Get information Ubuntu
+        id: info_ubuntu
+        uses: home-assistant/actions/helpers/info@master
+        with:
+          path: "${{ github.workspace }}/ubuntu"
 
-    - name: Get information Raspbian
-      id: info_raspbian
-      uses: home-assistant/actions/helpers/info@master
-      with:
-        path: "${{ github.workspace }}/raspbian"
-      
-    - name: Get version
-      id: version
-      uses: home-assistant/actions/helpers/version@master
-      with:
-        type: ${{ env.BUILD_TYPE }}
-  
+      - name: Get information Raspbian
+        id: info_raspbian
+        uses: home-assistant/actions/helpers/info@master
+        with:
+          path: "${{ github.workspace }}/raspbian"
+
+      - name: Get version
+        id: version
+        uses: home-assistant/actions/helpers/version@master
+        with:
+          type: ${{ env.BUILD_TYPE }}
+
   build_alpine:
     name: Build ${{ matrix.arch }} alpine ${{ matrix.version }} base image
     needs: init
@@ -73,38 +73,38 @@ jobs:
         arch: ${{ fromJson(needs.init.outputs.architectures_alpine) }}
         version: ["3.15", "3.16", "3.17", "3.18"]
     steps:
-    - name: Checkout the repository
-      uses: actions/checkout@v3
+      - name: Checkout the repository
+        uses: actions/checkout@v3
 
-    - name: Login to GitHub Container Registry
-      if: github.event_name == 'release'
-      uses: docker/login-action@v2
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        if: github.event_name == 'release'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Set build arguments
-      shell: bash
-      run: |
-        if [[ "${{ github.event_name }}" != "release" ]]; then
-          echo "BUILD_ARGS=--test" >> $GITHUB_ENV
-        elif [[ "${{ env.ALPINE_LATEST }}" != "${{ matrix.version }}" ]]; then
-          echo "BUILD_ARGS=--no-latest" >> $GITHUB_ENV
-        fi
-    
-    - name: Build base image
-      uses: home-assistant/builder@2023.06.0
-      with:
-        args: |
-          $BUILD_ARGS \
-          --${{ matrix.arch }} \
-          --target /data/alpine \
-          --cosign \
-          --release ${{ needs.init.outputs.release }} \
-          --base ${{ matrix.version }}
-      env:
-        CAS_API_KEY: ${{ secrets.CAS_TOKEN }}
+      - name: Set build arguments
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" != "release" ]]; then
+            echo "BUILD_ARGS=--test" >> $GITHUB_ENV
+          elif [[ "${{ env.ALPINE_LATEST }}" != "${{ matrix.version }}" ]]; then
+            echo "BUILD_ARGS=--no-latest" >> $GITHUB_ENV
+          fi
+
+      - name: Build base image
+        uses: home-assistant/builder@2023.06.0
+        with:
+          args: |
+            $BUILD_ARGS \
+            --${{ matrix.arch }} \
+            --target /data/alpine \
+            --cosign \
+            --release ${{ needs.init.outputs.release }} \
+            --base ${{ matrix.version }}
+        env:
+          CAS_API_KEY: ${{ secrets.CAS_TOKEN }}
 
   build_debian:
     name: Build ${{ matrix.arch }} debian ${{ matrix.version }} base image
@@ -117,41 +117,41 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson(needs.init.outputs.architectures_debian) }}
-        version: ["buster", "bullseye", "bookworm"] 
+        version: ["buster", "bullseye", "bookworm"]
     steps:
-    - name: Checkout the repository
-      uses: actions/checkout@v3
+      - name: Checkout the repository
+        uses: actions/checkout@v3
 
-    - name: Login to GitHub Container Registry
-      if: github.event_name == 'release'
-      uses: docker/login-action@v2
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        if: github.event_name == 'release'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Set build arguments
-      shell: bash
-      run: |
-        if [[ "${{ github.event_name }}" != "release" ]]; then
-          echo "BUILD_ARGS=--test" >> $GITHUB_ENV
-        elif [[ "${{ env.DEBIAN_LATEST }}" != "${{ matrix.version }}" ]]; then
-          echo "BUILD_ARGS=--no-latest" >> $GITHUB_ENV
-        fi
-    
-    - name: Build base image
-      uses: home-assistant/builder@2023.06.0
-      with:
-        args: |
-          $BUILD_ARGS \
-          --${{ matrix.arch }} \
-          --target /data/debian \
-          --cosign \
-          --release ${{ needs.init.outputs.release }} \
-          --version-from ${{ matrix.version }}-slim \
-          --base ${{ matrix.version }}
-      env:
-        CAS_API_KEY: ${{ secrets.CAS_TOKEN }}
+      - name: Set build arguments
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" != "release" ]]; then
+            echo "BUILD_ARGS=--test" >> $GITHUB_ENV
+          elif [[ "${{ env.DEBIAN_LATEST }}" != "${{ matrix.version }}" ]]; then
+            echo "BUILD_ARGS=--no-latest" >> $GITHUB_ENV
+          fi
+
+      - name: Build base image
+        uses: home-assistant/builder@2023.06.0
+        with:
+          args: |
+            $BUILD_ARGS \
+            --${{ matrix.arch }} \
+            --target /data/debian \
+            --cosign \
+            --release ${{ needs.init.outputs.release }} \
+            --version-from ${{ matrix.version }}-slim \
+            --base ${{ matrix.version }}
+        env:
+          CAS_API_KEY: ${{ secrets.CAS_TOKEN }}
 
   build_ubuntu:
     name: Build ${{ matrix.arch }} ubuntu ${{ matrix.version }} base image
@@ -164,40 +164,40 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson(needs.init.outputs.architectures_ubuntu) }}
-        version: ["16.04", "18.04", "20.04"] 
+        version: ["16.04", "18.04", "20.04"]
     steps:
-    - name: Checkout the repository
-      uses: actions/checkout@v3
+      - name: Checkout the repository
+        uses: actions/checkout@v3
 
-    - name: Login to GitHub Container Registry
-      if: github.event_name == 'release'
-      uses: docker/login-action@v2
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        if: github.event_name == 'release'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Set build arguments
-      shell: bash
-      run: |
-        if [[ "${{ github.event_name }}" != "release" ]]; then
-          echo "BUILD_ARGS=--test" >> $GITHUB_ENV
-        elif [[ "${{ env.UBUNTU_LATEST }}" != "${{ matrix.version }}" ]]; then
-          echo "BUILD_ARGS=--no-latest" >> $GITHUB_ENV
-        fi
-    
-    - name: Build base image
-      uses: home-assistant/builder@2023.06.0
-      with:
-        args: |
-          $BUILD_ARGS \
-          --${{ matrix.arch }} \
-          --target /data/ubuntu \
-          --cosign \
-          --release ${{ needs.init.outputs.release }} \
-          --base ${{ matrix.version }}
-      env:
-        CAS_API_KEY: ${{ secrets.CAS_TOKEN }}
+      - name: Set build arguments
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" != "release" ]]; then
+            echo "BUILD_ARGS=--test" >> $GITHUB_ENV
+          elif [[ "${{ env.UBUNTU_LATEST }}" != "${{ matrix.version }}" ]]; then
+            echo "BUILD_ARGS=--no-latest" >> $GITHUB_ENV
+          fi
+
+      - name: Build base image
+        uses: home-assistant/builder@2023.06.0
+        with:
+          args: |
+            $BUILD_ARGS \
+            --${{ matrix.arch }} \
+            --target /data/ubuntu \
+            --cosign \
+            --release ${{ needs.init.outputs.release }} \
+            --base ${{ matrix.version }}
+        env:
+          CAS_API_KEY: ${{ secrets.CAS_TOKEN }}
 
   build_raspbian:
     name: Build ${{ matrix.arch }} raspbian ${{ matrix.version }} base image
@@ -210,41 +210,41 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson(needs.init.outputs.architectures_raspbian) }}
-        version: ["buster", "bullseye", "bookworm"] 
+        version: ["buster", "bullseye", "bookworm"]
     steps:
-    - name: Checkout the repository
-      uses: actions/checkout@v3
+      - name: Checkout the repository
+        uses: actions/checkout@v3
 
-    - name: Login to GitHub Container Registry
-      if: github.event_name == 'release'
-      uses: docker/login-action@v2
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        if: github.event_name == 'release'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Set build arguments
-      shell: bash
-      run: |
-        if [[ "${{ github.event_name }}" != "release" ]]; then
-          echo "BUILD_ARGS=--test" >> $GITHUB_ENV
-        elif [[ "${{ env.RASPBIAN_LATEST }}" != "${{ matrix.version }}" ]]; then
-          echo "BUILD_ARGS=--no-latest" >> $GITHUB_ENV
-        fi
-    
-    - name: Build base image
-      uses: home-assistant/builder@2023.06.0
-      with:
-        args: |
-          $BUILD_ARGS \
-          --${{ matrix.arch }} \
-          --target /data/raspbian \
-          --cosign \
-          --release ${{ needs.init.outputs.release }} \
-          --version-from ${{ matrix.version }}-slim \
-          --base ${{ matrix.version }}
-      env:
-        CAS_API_KEY: ${{ secrets.CAS_TOKEN }}
+      - name: Set build arguments
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" != "release" ]]; then
+            echo "BUILD_ARGS=--test" >> $GITHUB_ENV
+          elif [[ "${{ env.RASPBIAN_LATEST }}" != "${{ matrix.version }}" ]]; then
+            echo "BUILD_ARGS=--no-latest" >> $GITHUB_ENV
+          fi
+
+      - name: Build base image
+        uses: home-assistant/builder@2023.06.0
+        with:
+          args: |
+            $BUILD_ARGS \
+            --${{ matrix.arch }} \
+            --target /data/raspbian \
+            --cosign \
+            --release ${{ needs.init.outputs.release }} \
+            --version-from ${{ matrix.version }}-slim \
+            --base ${{ matrix.version }}
+        env:
+          CAS_API_KEY: ${{ secrets.CAS_TOKEN }}
 
   build_python:
     name: Build ${{ matrix.arch }} alpine ${{ matrix.version }} - python ${{ matrix.python }} base image
@@ -260,37 +260,37 @@ jobs:
         version: ["3.16", "3.17", "3.18"]
         python: ["3.9", "3.10", "3.11"]
     steps:
-    - name: Checkout the repository
-      uses: actions/checkout@v3
+      - name: Checkout the repository
+        uses: actions/checkout@v3
 
-    - name: Login to GitHub Container Registry
-      if: github.event_name == 'release'
-      uses: docker/login-action@v2
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        if: github.event_name == 'release'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Set build arguments
-      shell: bash
-      run: |
-        if [[ "${{ github.event_name }}" != "release" ]]; then
-          echo "BUILD_ARGS=--test" >> $GITHUB_ENV
-        elif [[ "${{ env.ALPINE_LATEST }}" != "${{ matrix.version }}" ]] || [[ "${{ env.PYTHON_LATEST }}" != "${{ matrix.python }}" ]]; then
-          echo "BUILD_ARGS=--no-latest" >> $GITHUB_ENV
-        fi
-    
-    - name: Build base image
-      uses: home-assistant/builder@2023.06.0
-      with:
-        args: |
-          $BUILD_ARGS \
-          --${{ matrix.arch }} \
-          --target "/data/python/${{ matrix.python }}" \
-          --cosign \
-          --release ${{ needs.init.outputs.release }} \
-          --version-from ${{ matrix.version }} \
-          --version ${{ matrix.python }} \
-          --base ${{ matrix.python }}-alpine${{ matrix.version }}
-      env:
-        CAS_API_KEY: ${{ secrets.CAS_TOKEN }}
+      - name: Set build arguments
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" != "release" ]]; then
+            echo "BUILD_ARGS=--test" >> $GITHUB_ENV
+          elif [[ "${{ env.ALPINE_LATEST }}" != "${{ matrix.version }}" ]] || [[ "${{ env.PYTHON_LATEST }}" != "${{ matrix.python }}" ]]; then
+            echo "BUILD_ARGS=--no-latest" >> $GITHUB_ENV
+          fi
+
+      - name: Build base image
+        uses: home-assistant/builder@2023.06.0
+        with:
+          args: |
+            $BUILD_ARGS \
+            --${{ matrix.arch }} \
+            --target "/data/python/${{ matrix.python }}" \
+            --cosign \
+            --release ${{ needs.init.outputs.release }} \
+            --version-from ${{ matrix.version }} \
+            --version ${{ matrix.python }} \
+            --base ${{ matrix.python }}-alpine${{ matrix.version }}
+        env:
+          CAS_API_KEY: ${{ secrets.CAS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -39,15 +39,15 @@ We support the latest 3 release with the latest 3 Alpine version.
 
 ### Debian images
 
-**Note**: We prefer the alpine based version because it's more IoT friendly. In some case, you need a glibc system like this.
+**Note**: We prefer the Alpine based version because it's more IoT friendly. In some case, you need a glibc system like this.
 
 | Image | OS | Tags | latest |
 |-------|----|------|--------|
-| armv7-base-debian | Debian | buster, bullseye, bookworm | bullseye |
-| armhf-base-debian | Debian | buster, bullseye, bookworm | bullseye |
-| aarch64-base-debian | Debain | buster, bullseye, bookworm | bullseye |
-| amd64-base-debian | Debain | buster, bullseye, bookworm | bullseye |
-| i386-base-debian | Debain | buster, bullseye, bookworm | bullseye |
+| armv7-base-debian | Debian | buster, bullseye, bookworm | bookworm |
+| armhf-base-debian | Debian | buster, bullseye, bookworm | bookworm |
+| aarch64-base-debian | Debain | buster, bullseye, bookworm | bookworm |
+| amd64-base-debian | Debain | buster, bullseye, bookworm | bookworm |
+| i386-base-debian | Debain | buster, bullseye, bookworm | bookworm |
 
 ### Ubuntu images
 


### PR DESCRIPTION
Debian Bookworm is now stable and has been made available on Dockerhub:

Ref: <https://github.com/docker-library/official-images/pull/14832>

This PR marks it as the main stable distribution for our Debian images too.

PS: Prettier formatted the YAML file. Maybe not a bad change? Otherwise, I'm happy to soft reset and save without formatting. The only actual changes are: setting `DEBIAN_LATEST` to `bookworm` and adjusted the readme.

