### PR TITLE
Upgrade Python to 3.10.13 and 3.11.5

### DIFF
--- a/python/3.10/build.yaml
+++ b/python/3.10/build.yaml
@@ -12,7 +12,7 @@ cosign:
   base_identity: https://github.com/home-assistant/docker-base/.*
   identity: https://github.com/home-assistant/docker-base/.*
 args:
-  PYTHON_VERSION: 3.10.12
+  PYTHON_VERSION: 3.10.13
   PIP_VERSION: 23.1.2
   GPG_KEY: A035C8C19219BA821ECEA86B64E628F8D684696D
 labels:

--- a/python/3.11/build.yaml
+++ b/python/3.11/build.yaml
@@ -12,7 +12,7 @@ cosign:
   base_identity: https://github.com/home-assistant/docker-base/.*
   identity: https://github.com/home-assistant/docker-base/.*
 args:
-  PYTHON_VERSION: 3.11.4
+  PYTHON_VERSION: 3.11.5
   PIP_VERSION: 23.1.2
   GPG_KEY: A035C8C19219BA821ECEA86B64E628F8D684696D
 labels:


### PR DESCRIPTION
Upgrades Python 3.10 to 3.10.13 and Python 3.11 to 3.11.5

Fixes [CVE-2023-40217](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-40217)

ref: <https://github.com/python/cpython/issues/108310>