### PR TITLE
Update pip to 23.2.1

### DIFF
--- a/python/3.10/build.yaml
+++ b/python/3.10/build.yaml
@@ -13,7 +13,7 @@ cosign:
   identity: https://github.com/home-assistant/docker-base/.*
 args:
   PYTHON_VERSION: 3.10.13
-  PIP_VERSION: 23.1.2
+  PIP_VERSION: 23.2.1
   GPG_KEY: A035C8C19219BA821ECEA86B64E628F8D684696D
 labels:
   io.hass.base.name: python

--- a/python/3.11/build.yaml
+++ b/python/3.11/build.yaml
@@ -13,7 +13,7 @@ cosign:
   identity: https://github.com/home-assistant/docker-base/.*
 args:
   PYTHON_VERSION: 3.11.5
-  PIP_VERSION: 23.1.2
+  PIP_VERSION: 23.2.1
   GPG_KEY: A035C8C19219BA821ECEA86B64E628F8D684696D
 labels:
   io.hass.base.name: python

--- a/python/3.9/build.yaml
+++ b/python/3.9/build.yaml
@@ -13,7 +13,7 @@ cosign:
   identity: https://github.com/home-assistant/docker-base/.*
 args:
   PYTHON_VERSION: 3.9.17
-  PIP_VERSION: 23.1.2
+  PIP_VERSION: 23.2.1
   GPG_KEY: E3FF2839C048B25C084DEBE9B26995E310250568
 labels:
   io.hass.base.name: python


### PR DESCRIPTION
SSIA

Upgrades `pip` to 23.2.1, so we can leverage our new PEP 503 compliant Wheels index correctly.
