### PR TITLE
Update pip to 23.3

### DIFF
--- a/python/3.10/build.yaml
+++ b/python/3.10/build.yaml
@@ -10,7 +10,7 @@ cosign:
   identity: https://github.com/home-assistant/docker-base/.*
 args:
   PYTHON_VERSION: 3.10.13
-  PIP_VERSION: 23.2.1
+  PIP_VERSION: 23.3
   GPG_KEY: A035C8C19219BA821ECEA86B64E628F8D684696D
 labels:
   io.hass.base.name: python

--- a/python/3.11/build.yaml
+++ b/python/3.11/build.yaml
@@ -10,7 +10,7 @@ cosign:
   identity: https://github.com/home-assistant/docker-base/.*
 args:
   PYTHON_VERSION: 3.11.5
-  PIP_VERSION: 23.2.1
+  PIP_VERSION: 23.3
   GPG_KEY: A035C8C19219BA821ECEA86B64E628F8D684696D
 labels:
   io.hass.base.name: python

--- a/python/3.12/build.yaml
+++ b/python/3.12/build.yaml
@@ -10,7 +10,7 @@ cosign:
   identity: https://github.com/home-assistant/docker-base/.*
 args:
   PYTHON_VERSION: 3.12.0
-  PIP_VERSION: 23.2.1
+  PIP_VERSION: 23.3
   GPG_KEY: 7169605F62C751356D054A26A821E680E5FA6305
 labels:
   io.hass.base.name: python


### PR DESCRIPTION
Upgrades `pip` to 23.3:

<https://pip.pypa.io/en/stable/news/#v23-3>