### PR TITLE
Pre-configure pip in Alpine base images

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -87,6 +87,9 @@ RUN \
     && apk del .build-deps \
     && rm -rf /usr/src/*
 
+# Root filesystem
+COPY rootfs /
+
 # S6-Overlay
 WORKDIR /
 ENTRYPOINT ["/init"]

--- a/alpine/rootfs/etc/pip.conf
+++ b/alpine/rootfs/etc/pip.conf
@@ -1,0 +1,5 @@
+[global]
+disable-pip-version-check = true
+extra-index-url = https://wheels.home-assistant.io/musllinux-index/
+no-cache-dir = false
+prefer-binary = true


### PR DESCRIPTION
This PR pre-configures `pip` in our Alpine base images.

Related: 
- https://github.com/home-assistant/docker/pull/303
- https://github.com/home-assistant/core/pull/102126