### PR TITLE
Update Bashio to v0.16.2

### DIFF
--- a/alpine/build.yaml
+++ b/alpine/build.yaml
@@ -8,7 +8,7 @@ build_from:
 cosign:
   identity: https://github.com/home-assistant/docker-base/.*
 args:
-  BASHIO_VERSION: 0.15.0
+  BASHIO_VERSION: 0.16.2
   TEMPIO_VERSION: 2021.09.0
   S6_OVERLAY_VERSION: 3.1.5.0
   JEMALLOC_VERSION: 5.3.0

--- a/debian/build.yaml
+++ b/debian/build.yaml
@@ -8,7 +8,7 @@ build_from:
 cosign:
   identity: https://github.com/home-assistant/docker-base/.*
 args:
-  BASHIO_VERSION: 0.15.0
+  BASHIO_VERSION: 0.16.2
   TEMPIO_VERSION: 2021.09.0
   S6_OVERLAY_VERSION: 3.1.5.0
 labels:

--- a/raspbian/build.yaml
+++ b/raspbian/build.yaml
@@ -4,7 +4,7 @@ build_from:
 cosign:
   identity: https://github.com/home-assistant/docker-base/.*
 args:
-  BASHIO_VERSION: 0.15.0
+  BASHIO_VERSION: 0.16.2
   TEMPIO_VERSION: 2021.09.0
   S6_OVERLAY_VERSION: 3.1.5.0
 labels:

--- a/ubuntu/build.yaml
+++ b/ubuntu/build.yaml
@@ -6,7 +6,7 @@ build_from:
 cosign:
   identity: https://github.com/home-assistant/docker-base/.*
 args:
-  BASHIO_VERSION: 0.15.0
+  BASHIO_VERSION: 0.16.2
   TEMPIO_VERSION: 2021.09.0
   S6_OVERLAY_VERSION: 3.1.5.0
 labels:


### PR DESCRIPTION
Release notes:

- https://github.com/hassio-addons/bashio/releases/tag/v0.16.0
- https://github.com/hassio-addons/bashio/releases/tag/v0.16.1
- https://github.com/hassio-addons/bashio/releases/tag/v0.16.2