### PR TITLE
Update S6 Overlay to v3.1.6.2

### DIFF
--- a/alpine/build.yaml
+++ b/alpine/build.yaml
@@ -10,7 +10,7 @@ cosign:
 args:
   BASHIO_VERSION: 0.15.0
   TEMPIO_VERSION: 2021.09.0
-  S6_OVERLAY_VERSION: 3.1.5.0
+  S6_OVERLAY_VERSION: 3.1.6.2
   JEMALLOC_VERSION: 5.3.0
 labels:
   io.hass.base.name: alpine

--- a/debian/build.yaml
+++ b/debian/build.yaml
@@ -10,7 +10,7 @@ cosign:
 args:
   BASHIO_VERSION: 0.15.0
   TEMPIO_VERSION: 2021.09.0
-  S6_OVERLAY_VERSION: 3.1.5.0
+  S6_OVERLAY_VERSION: 3.1.6.2
 labels:
   io.hass.base.name: debian
   org.opencontainers.image.source: https://github.com/home-assistant/docker-base

--- a/raspbian/build.yaml
+++ b/raspbian/build.yaml
@@ -6,7 +6,7 @@ cosign:
 args:
   BASHIO_VERSION: 0.15.0
   TEMPIO_VERSION: 2021.09.0
-  S6_OVERLAY_VERSION: 3.1.5.0
+  S6_OVERLAY_VERSION: 3.1.6.2
 labels:
   io.hass.base.name: raspbian
   org.opencontainers.image.source: https://github.com/home-assistant/docker-base

--- a/ubuntu/build.yaml
+++ b/ubuntu/build.yaml
@@ -8,7 +8,7 @@ cosign:
 args:
   BASHIO_VERSION: 0.15.0
   TEMPIO_VERSION: 2021.09.0
-  S6_OVERLAY_VERSION: 3.1.5.0
+  S6_OVERLAY_VERSION: 3.1.6.2
 labels:
   io.hass.base.name: ubuntu
   org.opencontainers.image.source: https://github.com/home-assistant/docker-base


### PR DESCRIPTION
Contains mostly bugfixes, no changes/impact for us (or add-on maintainers).

Release notes:
- https://github.com/just-containers/s6-overlay/releases/tag/v3.1.6.0
- https://github.com/just-containers/s6-overlay/releases/tag/v3.1.6.1
- https://github.com/just-containers/s6-overlay/releases/tag/v3.1.6.2