### PR TITLE
Improve jemalloc installation

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -38,6 +38,7 @@ RUN \
         ca-certificates \
         curl \
         jq \
+        libstdc++ \
         tzdata \
         xz \
     \
@@ -73,7 +74,7 @@ RUN \
     && ./autogen.sh \
         --with-lg-page=16 \
     && make -j "$(nproc)" \
-    && make install \
+    && make install_lib_shared install_bin \
     \
     && mkdir -p /usr/src/bashio \
     && curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \


### PR DESCRIPTION
Make sure all dependencies of jemalloc are installed. Also only install the shared libraries since we use the shared library via pre-load only. This safes about 42MB of disk space for the base image.