### PR TITLE
Update Python 3.11.8/3.12.2 and pip 24.0

### DIFF
--- a/python/3.10/build.yaml
+++ b/python/3.10/build.yaml
@@ -10,7 +10,7 @@ cosign:
   identity: https://github.com/home-assistant/docker-base/.*
 args:
   PYTHON_VERSION: 3.10.13
-  PIP_VERSION: 23.3.1
+  PIP_VERSION: 24.0
   GPG_KEY: A035C8C19219BA821ECEA86B64E628F8D684696D
 labels:
   io.hass.base.name: python

--- a/python/3.11/build.yaml
+++ b/python/3.11/build.yaml
@@ -9,8 +9,8 @@ cosign:
   base_identity: https://github.com/home-assistant/docker-base/.*
   identity: https://github.com/home-assistant/docker-base/.*
 args:
-  PYTHON_VERSION: 3.11.6
-  PIP_VERSION: 23.3.1
+  PYTHON_VERSION: 3.11.8
+  PIP_VERSION: 24.0
   GPG_KEY: A035C8C19219BA821ECEA86B64E628F8D684696D
 labels:
   io.hass.base.name: python

--- a/python/3.12/build.yaml
+++ b/python/3.12/build.yaml
@@ -9,8 +9,8 @@ cosign:
   base_identity: https://github.com/home-assistant/docker-base/.*
   identity: https://github.com/home-assistant/docker-base/.*
 args:
-  PYTHON_VERSION: 3.12.1
-  PIP_VERSION: 23.3.1
+  PYTHON_VERSION: 3.12.2
+  PIP_VERSION: 24.0
   GPG_KEY: 7169605F62C751356D054A26A821E680E5FA6305
 labels:
   io.hass.base.name: python


### PR DESCRIPTION
SSIA. This PR updates:

- Python 3.12.1 to 3.12.2
- Python 3.11.6 to 3.11.8

And updates `pip` to 24.0 for all Python versions.

The pip bump contains a fix for 502 status code errors we have been experiencing. 
<https://pip.pypa.io/en/stable/news/> / <https://github.com/pypa/pip/pull/12500>