### PR TITLE
Add iputils-ping package to support non-root containers

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -37,6 +37,7 @@ RUN \
         bind-tools \
         ca-certificates \
         curl \
+        iputils-ping \
         jq \
         libstdc++ \
         tzdata \


### PR DESCRIPTION
This replaces the busybox ping which can not support non-root containers. The size increase is minimal (< 90kB).

This fixes:
https://github.com/home-assistant/core/issues/103428
https://github.com/home-assistant/core/issues/106293