### PR TITLE
Add Alpine Linux 3.20, drop 3.16

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   BUILD_TYPE: base
-  ALPINE_LATEST: "3.19"
+  ALPINE_LATEST: "3.20"
   DEBIAN_LATEST: "bookworm"
   UBUNTU_LATEST: "20.4"
   RASPBIAN_LATEST: "bullseye"
@@ -71,7 +71,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson(needs.init.outputs.architectures_alpine) }}
-        version: ["3.16", "3.17", "3.18", "3.19"]
+        version: ["3.17", "3.18", "3.19", "3.20"]
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4.1.6

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ We support version that are not EOL: https://alpinelinux.org/releases/
 
 | Image | OS | Tags | latest |
 |-------|----|------|--------|
-| armhf-base | Alpine | 3.16, 3.17 3.18, 3.19 | 3.19 |
-| armv7-base | Alpine | 3.16, 3.17 3.18, 3.19 | 3.19 |
-| aarch64-base | Alpine | 3.16, 3.17 3.18, 3.19 | 3.19 |
-| amd64-base | Alpine | 3.16, 3.17 3.18, 3.19 | 3.19 |
-| i386-base | Alpine | 3.16, 3.17 3.18, 3.19 | 3.19 |
+| armhf-base | Alpine | 3.17 3.18, 3.19, 3.20 | 3.20 |
+| armv7-base | Alpine | 3.17 3.18, 3.19, 3.20 | 3.20 |
+| aarch64-base | Alpine | 3.17 3.18, 3.19, 3.20 | 3.20 |
+| amd64-base | Alpine | 3.17 3.18, 3.19, 3.20 | 3.20 |
+| i386-base | Alpine | 3.17 3.18, 3.19, 3.20 | 3.20 |
 
 ### jemalloc
 


### PR DESCRIPTION
SSIA

Add Alpine Linux 3.20: https://alpinelinux.org/posts/Alpine-3.20.0-released.html

This means the oldest drops from our support, which is Alpine 3.16