### PR TITLE
Upgrade Python base images to Alpine 3.20, drop 3.17

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -249,7 +249,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson(needs.init.outputs.architectures_alpine) }}
-        version: ["3.17", "3.18", "3.19"]
+        version: ["3.18", "3.19", "3.20"]
         python: ["3.10", "3.11", "3.12"]
     steps:
       - name: Checkout the repository

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ We support the latest 3 release with the latest 3 Alpine version.
 
 | Image | OS | Tags | latest |
 |-------|----|------|--------|
-| armhf-base-python | Alpine | 3.10, 3.11, 3.12, 3.10-alpine3.17, 3.10-alpine3.18, 3.10-alpine3.19, 3.11-alpine3.17, 3.11-alpine3.18, 3.11-alpine3.19, 3.12-alpine3.17, 3.12-alpine3.18, 3.12-alpine3.19 | 3.12-alpine3.19 |
-| armv7-base-python | Alpine | 3.10, 3.11, 3.12, 3.10-alpine3.17, 3.10-alpine3.18, 3.10-alpine3.19, 3.11-alpine3.17, 3.11-alpine3.18, 3.11-alpine3.19, 3.12-alpine3.17, 3.12-alpine3.18, 3.12-alpine3.19 | 3.12-alpine3.19 |
-| aarch64-base-python | Alpine | 3.10, 3.11, 3.12, 3.10-alpine3.17, 3.10-alpine3.18, 3.10-alpine3.19, 3.11-alpine3.17, 3.11-alpine3.18, 3.11-alpine3.19, 3.12-alpine3.17, 3.12-alpine3.18, 3.12-alpine3.19 | 3.12-alpine3.19 |
-| amd64-base-python | Alpine | 3.10, 3.11, 3.12, 3.10-alpine3.17, 3.10-alpine3.18, 3.10-alpine3.19, 3.11-alpine3.17, 3.11-alpine3.18, 3.11-alpine3.19, 3.12-alpine3.17, 3.12-alpine3.18, 3.12-alpine3.19 | 3.12-alpine3.19 |
-| i386-base-python | Alpine | 3.10, 3.11, 3.12, 3.10-alpine3.17, 3.10-alpine3.18, 3.10-alpine3.19, 3.11-alpine3.17, 3.11-alpine3.18, 3.11-alpine3.19, 3.12-alpine3.17, 3.12-alpine3.18, 3.12-alpine3.19 | 3.12-alpine3.19 |
+| armhf-base-python | Alpine | 3.10, 3.11, 3.12, 3.10-alpine3.18, 3.10-alpine3.19, 3.10-alpine3.20, 3.11-alpine3.18, 3.11-alpine3.19, 3.11-alpine3.20, 3.12-alpine3.18, 3.12-alpine3.19, 3.12-alpine3.20 | 3.12-alpine3.20 |
+| armv7-base-python | Alpine | 3.10, 3.11, 3.12, 3.10-alpine3.18, 3.10-alpine3.19, 3.10-alpine3.20, 3.11-alpine3.18, 3.11-alpine3.19, 3.11-alpine3.20, 3.12-alpine3.18, 3.12-alpine3.19, 3.12-alpine3.20 | 3.12-alpine3.20 |
+| aarch64-base-python | Alpine | 3.10, 3.11, 3.12, 3.10-alpine3.18, 3.10-alpine3.19, 3.10-alpine3.20, 3.11-alpine3.18, 3.11-alpine3.19, 3.11-alpine3.20, 3.12-alpine3.18, 3.12-alpine3.19, 3.12-alpine3.20 | 3.12-alpine3.20 |
+| amd64-base-python | Alpine | 3.10, 3.11, 3.12, 3.10-alpine3.18, 3.10-alpine3.19, 3.10-alpine3.20, 3.11-alpine3.18, 3.11-alpine3.19, 3.11-alpine3.20, 3.12-alpine3.18, 3.12-alpine3.19, 3.12-alpine3.20 | 3.12-alpine3.20 |
+| i386-base-python | Alpine | 3.10, 3.11, 3.12, 3.10-alpine3.18, 3.10-alpine3.19, 3.10-alpine3.20, 3.11-alpine3.18, 3.11-alpine3.19, 3.11-alpine3.20, 3.12-alpine3.18, 3.12-alpine3.19, 3.12-alpine3.20 | 3.12-alpine3.20 |
 
 ## Others
 


### PR DESCRIPTION
Upgrades the Python base images to have the Alpine 3.20 variant (Alpine Linux 3.20 was added in #268).

As we only support the last 3 Alpine versions for our Python images, this means this drops Alpine 3.17 for the Python images.