### PR TITLE
Update Python 3.10.14/3.11.9/3.12.4 & pip 24.1

### DIFF
--- a/python/3.10/build.yaml
+++ b/python/3.10/build.yaml
@@ -9,8 +9,8 @@ cosign:
   base_identity: https://github.com/home-assistant/docker-base/.*
   identity: https://github.com/home-assistant/docker-base/.*
 args:
-  PYTHON_VERSION: 3.10.13
-  PIP_VERSION: 24.0
+  PYTHON_VERSION: 3.10.14
+  PIP_VERSION: 24.1
   GPG_KEY: A035C8C19219BA821ECEA86B64E628F8D684696D
 labels:
   io.hass.base.name: python

--- a/python/3.11/build.yaml
+++ b/python/3.11/build.yaml
@@ -9,8 +9,8 @@ cosign:
   base_identity: https://github.com/home-assistant/docker-base/.*
   identity: https://github.com/home-assistant/docker-base/.*
 args:
-  PYTHON_VERSION: 3.11.8
-  PIP_VERSION: 24.0
+  PYTHON_VERSION: 3.11.9
+  PIP_VERSION: 24.1
   GPG_KEY: A035C8C19219BA821ECEA86B64E628F8D684696D
 labels:
   io.hass.base.name: python

--- a/python/3.12/build.yaml
+++ b/python/3.12/build.yaml
@@ -9,8 +9,8 @@ cosign:
   base_identity: https://github.com/home-assistant/docker-base/.*
   identity: https://github.com/home-assistant/docker-base/.*
 args:
-  PYTHON_VERSION: 3.12.2
-  PIP_VERSION: 24.0
+  PYTHON_VERSION: 3.12.4
+  PIP_VERSION: 24.1
   GPG_KEY: 7169605F62C751356D054A26A821E680E5FA6305
 labels:
   io.hass.base.name: python


### PR DESCRIPTION
SSIA, updates:

- Python 3.10 to 3.10.4
- Python 3.11 to 3.11.9
- Python 3.12 to 3.12.4
- pip for all Python releases to 24.1

