### PR TITLE
Remove debian buster as not supported

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -115,7 +115,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson(needs.init.outputs.architectures_debian) }}
-        version: ["buster", "bullseye", "bookworm"]
+        version: ["bullseye", "bookworm"]
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4.1.7
@@ -204,7 +204,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson(needs.init.outputs.architectures_raspbian) }}
-        version: ["buster", "bullseye", "bookworm"]
+        version: ["bullseye", "bookworm"]
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4.1.7

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ We support the latest 3 release with the latest 3 Alpine version.
 
 | Image | OS | Tags | latest |
 |-------|----|------|--------|
-| armv7-base-debian | Debian | buster, bullseye, bookworm | bookworm |
-| armhf-base-debian | Debian | buster, bullseye, bookworm | bookworm |
-| aarch64-base-debian | Debian | buster, bullseye, bookworm | bookworm |
-| amd64-base-debian | Debian | buster, bullseye, bookworm | bookworm |
-| i386-base-debian | Debian | buster, bullseye, bookworm | bookworm |
+| armv7-base-debian | Debian | bullseye, bookworm | bookworm |
+| armhf-base-debian | Debian | bullseye, bookworm | bookworm |
+| aarch64-base-debian | Debian | bullseye, bookworm | bookworm |
+| amd64-base-debian | Debian | bullseye, bookworm | bookworm |
+| i386-base-debian | Debian | bullseye, bookworm | bookworm |
 
 ### Ubuntu images
 
@@ -64,5 +64,5 @@ We support the latest 3 release with the latest 3 Alpine version.
 
 | Image | OS | Tags | latest |
 |-------|----|------|--------|
-| armhf-base-raspbian | Raspbian | buster, bullseye, bookworm | bullseye |
+| armhf-base-raspbian | Raspbian | bullseye, bookworm | bullseye |
 


### PR DESCRIPTION
Remove Buster as the images with it are no longer being built.