### PR TITLE
Add debian trixie as next debian release

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -115,7 +115,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson(needs.init.outputs.architectures_debian) }}
-        version: ["bullseye", "bookworm"]
+        version: ["bullseye", "bookworm", "trixie"]
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4.1.7
@@ -204,7 +204,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson(needs.init.outputs.architectures_raspbian) }}
-        version: ["bullseye", "bookworm"]
+        version: ["bullseye", "bookworm", "trixie"]
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4.1.7

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ We support the latest 3 release with the latest 3 Alpine version.
 
 | Image | OS | Tags | latest |
 |-------|----|------|--------|
-| armv7-base-debian | Debian | bullseye, bookworm | bookworm |
-| armhf-base-debian | Debian | bullseye, bookworm | bookworm |
-| aarch64-base-debian | Debian | bullseye, bookworm | bookworm |
-| amd64-base-debian | Debian | bullseye, bookworm | bookworm |
-| i386-base-debian | Debian | bullseye, bookworm | bookworm |
+| armv7-base-debian | Debian | bullseye, bookworm, trixie | bookworm |
+| armhf-base-debian | Debian | bullseye, bookworm, trixie | bookworm |
+| aarch64-base-debian | Debian | bullseye, bookworm, trixie | bookworm |
+| amd64-base-debian | Debian | bullseye, bookworm, trixie | bookworm |
+| i386-base-debian | Debian | bullseye, bookworm, trixie | bookworm |
 
 ### Ubuntu images
 
@@ -64,5 +64,5 @@ We support the latest 3 release with the latest 3 Alpine version.
 
 | Image | OS | Tags | latest |
 |-------|----|------|--------|
-| armhf-base-raspbian | Raspbian | bullseye, bookworm | bullseye |
+| armhf-base-raspbian | Raspbian | bullseye, bookworm, trixie | bullseye |
 


### PR DESCRIPTION
docker images have already been successfully built using Debian Trixie as the source, so we can add it to the docker-base containers for further tracking of any build issues leading up to the debian release