### PR TITLE
Update Python 3.12.5 & pip 24.2

### DIFF
--- a/python/3.10/build.yaml
+++ b/python/3.10/build.yaml
@@ -10,7 +10,7 @@ cosign:
   identity: https://github.com/home-assistant/docker-base/.*
 args:
   PYTHON_VERSION: 3.10.14
-  PIP_VERSION: 24.1
+  PIP_VERSION: 24.2
   GPG_KEY: A035C8C19219BA821ECEA86B64E628F8D684696D
 labels:
   io.hass.base.name: python

--- a/python/3.11/build.yaml
+++ b/python/3.11/build.yaml
@@ -10,7 +10,7 @@ cosign:
   identity: https://github.com/home-assistant/docker-base/.*
 args:
   PYTHON_VERSION: 3.11.9
-  PIP_VERSION: 24.1
+  PIP_VERSION: 24.2
   GPG_KEY: A035C8C19219BA821ECEA86B64E628F8D684696D
 labels:
   io.hass.base.name: python

--- a/python/3.12/build.yaml
+++ b/python/3.12/build.yaml
@@ -9,8 +9,8 @@ cosign:
   base_identity: https://github.com/home-assistant/docker-base/.*
   identity: https://github.com/home-assistant/docker-base/.*
 args:
-  PYTHON_VERSION: 3.12.4
-  PIP_VERSION: 24.1
+  PYTHON_VERSION: 3.12.5
+  PIP_VERSION: 24.2
   GPG_KEY: 7169605F62C751356D054A26A821E680E5FA6305
 labels:
   io.hass.base.name: python


### PR DESCRIPTION
Updates Python to 3.12.5

https://pythoninsider.blogspot.com/2024/08/python-3125-released.html

And `pip` to 21.4

https://pip.pypa.io/en/stable/news/#v24-2

