### PR TITLE
Disable PGO tests

### DIFF
--- a/python/3.13/Dockerfile
+++ b/python/3.13/Dockerfile
@@ -86,6 +86,7 @@ RUN set -ex \
 # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
         EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
+        PROFILE_TASK="" \
     && make install \
     \
 	&& find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec scanelf --needed --nobanner --format '%n#p' '{}' ';' \


### PR DESCRIPTION
Alternative to #279
This PR disables the PGO tests completely.

https://docs.python.org/3/using/configure.html#envvar-PROFILE_TASK