### PR TITLE
Update pip to 24.3.1

### DIFF
--- a/python/3.11/build.yaml
+++ b/python/3.11/build.yaml
@@ -10,7 +10,7 @@ cosign:
   identity: https://github.com/home-assistant/docker-base/.*
 args:
   PYTHON_VERSION: 3.11.9
-  PIP_VERSION: 24.2
+  PIP_VERSION: 24.3.1
   GPG_KEY: A035C8C19219BA821ECEA86B64E628F8D684696D
 labels:
   io.hass.base.name: python

--- a/python/3.12/build.yaml
+++ b/python/3.12/build.yaml
@@ -10,7 +10,7 @@ cosign:
   identity: https://github.com/home-assistant/docker-base/.*
 args:
   PYTHON_VERSION: 3.12.5
-  PIP_VERSION: 24.2
+  PIP_VERSION: 24.3.1
   GPG_KEY: 7169605F62C751356D054A26A821E680E5FA6305
 labels:
   io.hass.base.name: python

--- a/python/3.13/build.yaml
+++ b/python/3.13/build.yaml
@@ -10,7 +10,7 @@ cosign:
   identity: https://github.com/home-assistant/docker-base/.*
 args:
   PYTHON_VERSION: 3.13.0
-  PIP_VERSION: 24.2
+  PIP_VERSION: 24.3.1
   GPG_KEY: 7169605F62C751356D054A26A821E680E5FA6305
 labels:
   io.hass.base.name: python


### PR DESCRIPTION
This PR updates `pip` in our Python images to 24.3.1

Changelog: https://pip.pypa.io/en/stable/news/#v24-3-1