### PR TITLE
Bump tempio to 2024.11.2

### DIFF
--- a/alpine/build.yaml
+++ b/alpine/build.yaml
@@ -9,7 +9,7 @@ cosign:
   identity: https://github.com/home-assistant/docker-base/.*
 args:
   BASHIO_VERSION: 0.16.2
-  TEMPIO_VERSION: 2021.09.0
+  TEMPIO_VERSION: 2024.11.2
   S6_OVERLAY_VERSION: 3.1.6.2
   JEMALLOC_VERSION: 5.3.0
 labels:

--- a/debian/build.yaml
+++ b/debian/build.yaml
@@ -9,7 +9,7 @@ cosign:
   identity: https://github.com/home-assistant/docker-base/.*
 args:
   BASHIO_VERSION: 0.16.2
-  TEMPIO_VERSION: 2021.09.0
+  TEMPIO_VERSION: 2024.11.2
   S6_OVERLAY_VERSION: 3.1.6.2
 labels:
   io.hass.base.name: debian

--- a/raspbian/build.yaml
+++ b/raspbian/build.yaml
@@ -5,7 +5,7 @@ cosign:
   identity: https://github.com/home-assistant/docker-base/.*
 args:
   BASHIO_VERSION: 0.16.2
-  TEMPIO_VERSION: 2021.09.0
+  TEMPIO_VERSION: 2024.11.2
   S6_OVERLAY_VERSION: 3.1.6.2
 labels:
   io.hass.base.name: raspbian

--- a/ubuntu/build.yaml
+++ b/ubuntu/build.yaml
@@ -7,7 +7,7 @@ cosign:
   identity: https://github.com/home-assistant/docker-base/.*
 args:
   BASHIO_VERSION: 0.16.2
-  TEMPIO_VERSION: 2021.09.0
+  TEMPIO_VERSION: 2024.11.2
   S6_OVERLAY_VERSION: 3.1.6.2
 labels:
   io.hass.base.name: ubuntu


### PR DESCRIPTION
The tempio 2024.11.2 contains no functional change but has been built with the latest Go version 1.23.