### PR TITLE
Add support for alpine 3.21 and drop 3.17

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   BUILD_TYPE: base
-  ALPINE_LATEST: "3.20"
+  ALPINE_LATEST: "3.21"
   DEBIAN_LATEST: "bookworm"
   UBUNTU_LATEST: "20.4"
   RASPBIAN_LATEST: "bullseye"
@@ -71,7 +71,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson(needs.init.outputs.architectures_alpine) }}
-        version: ["3.17", "3.18", "3.19", "3.20"]
+        version: ["3.18", "3.19", "3.20", "3.21"]
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4.2.2

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ We support version that are not EOL: https://alpinelinux.org/releases/
 
 | Image | OS | Tags | latest |
 |-------|----|------|--------|
-| armhf-base | Alpine | 3.17 3.18, 3.19, 3.20 | 3.20 |
-| armv7-base | Alpine | 3.17 3.18, 3.19, 3.20 | 3.20 |
-| aarch64-base | Alpine | 3.17 3.18, 3.19, 3.20 | 3.20 |
-| amd64-base | Alpine | 3.17 3.18, 3.19, 3.20 | 3.20 |
-| i386-base | Alpine | 3.17 3.18, 3.19, 3.20 | 3.20 |
+| armhf-base | Alpine | 3.18, 3.19, 3.20, 3.21 | 3.21 |
+| armv7-base | Alpine | 3.18, 3.19, 3.20, 3.21 | 3.21 |
+| aarch64-base | Alpine | 3.18, 3.19, 3.20, 3.21 | 3.21 |
+| amd64-base | Alpine | 3.18, 3.19, 3.20, 3.21 | 3.21 |
+| i386-base | Alpine | 3.18, 3.19, 3.20, 3.21 | 3.21 |
 
 ### jemalloc
 
@@ -65,4 +65,3 @@ We support the latest 3 release with the latest 3 Alpine version.
 | Image | OS | Tags | latest |
 |-------|----|------|--------|
 | armhf-base-raspbian | Raspbian | bullseye, bookworm | bullseye |
-


### PR DESCRIPTION
- Alpine `3.21` was release a few days ago.
https://alpinelinux.org/posts/Alpine-3.21.0-released.html
- Alpine `3.17` reached its EOL last month and is therefore dropped.

https://alpinelinux.org/releases/