### PR TITLE
Update Python images to alpine 3.21

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -249,7 +249,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson(needs.init.outputs.architectures_alpine) }}
-        version: ["3.18", "3.19", "3.20"]
+        version: ["3.19", "3.20", "3.21"]
         python: ["3.11", "3.12", "3.13"]
     steps:
       - name: Checkout the repository

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ We support the latest 3 release with the latest 3 Alpine version.
 
 | Image | OS | Tags | latest |
 |-------|----|------|--------|
-| armhf-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.18, 3.11-alpine3.19, 3.11-alpine3.20, 3.12-alpine3.18, 3.12-alpine3.19, 3.12-alpine3.20, 3.13-alpine3.18, 3.13-alpine3.19, 3.13-alpine3.20 | 3.13-alpine3.20 |
-| armv7-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.18, 3.11-alpine3.19, 3.11-alpine3.20, 3.12-alpine3.18, 3.12-alpine3.19, 3.12-alpine3.20, 3.13-alpine3.18, 3.13-alpine3.19, 3.13-alpine3.20 | 3.13-alpine3.20 |
-| aarch64-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.18, 3.11-alpine3.19, 3.11-alpine3.20, 3.12-alpine3.18, 3.12-alpine3.19, 3.12-alpine3.20, 3.13-alpine3.18, 3.13-alpine3.19, 3.13-alpine3.20 | 3.13-alpine3.20 |
-| amd64-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.18, 3.11-alpine3.19, 3.11-alpine3.20, 3.12-alpine3.18, 3.12-alpine3.19, 3.12-alpine3.20, 3.13-alpine3.18, 3.13-alpine3.19, 3.13-alpine3.20 | 3.13-alpine3.20 |
-| i386-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.18, 3.11-alpine3.19, 3.11-alpine3.20, 3.12-alpine3.18, 3.12-alpine3.19, 3.12-alpine3.20, 3.13-alpine3.18, 3.13-alpine3.19, 3.13-alpine3.20 | 3.13-alpine3.20 |
+| armhf-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.19, 3.11-alpine3.20, 3.11-alpine3.21, 3.12-alpine3.19, 3.12-alpine3.20, 3.12-alpine3.21, 3.13-alpine3.19, 3.13-alpine3.20, 3.13-alpine3.21 | 3.13-alpine3.21 |
+| armv7-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.19, 3.11-alpine3.20, 3.11-alpine3.21, 3.12-alpine3.19, 3.12-alpine3.20, 3.12-alpine3.21, 3.13-alpine3.19, 3.13-alpine3.20, 3.13-alpine3.21 | 3.13-alpine3.21 |
+| aarch64-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.19, 3.11-alpine3.20, 3.11-alpine3.21, 3.12-alpine3.19, 3.12-alpine3.20, 3.12-alpine3.21, 3.13-alpine3.19, 3.13-alpine3.20, 3.13-alpine3.21 | 3.13-alpine3.21 |
+| amd64-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.19, 3.11-alpine3.20, 3.11-alpine3.21, 3.12-alpine3.19, 3.12-alpine3.20, 3.12-alpine3.21, 3.13-alpine3.19, 3.13-alpine3.20, 3.13-alpine3.21 | 3.13-alpine3.21 |
+| i386-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.19, 3.11-alpine3.20, 3.11-alpine3.21, 3.12-alpine3.19, 3.12-alpine3.20, 3.12-alpine3.21, 3.13-alpine3.19, 3.13-alpine3.20, 3.13-alpine3.21 | 3.13-alpine3.21 |
 
 ## Others
 


### PR DESCRIPTION
Followup to #288

Might need a new release first for the `3.21` alpine base images to be available.