### PR TITLE
Add support for alpine 3.22 and drop 3.18

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -249,7 +249,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson(needs.init.outputs.architectures_alpine) }}
-        version: ["3.19", "3.20", "3.21", "3.22"]
+        version: ["3.20", "3.21", "3.22"]
         python: ["3.11", "3.12", "3.13"]
     steps:
       - name: Checkout the repository

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -249,7 +249,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson(needs.init.outputs.architectures_alpine) }}
-        version: ["3.20", "3.21", "3.22"]
+        version: ["3.19", "3.20", "3.21"]
         python: ["3.11", "3.12", "3.13"]
     steps:
       - name: Checkout the repository

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   BUILD_TYPE: base
-  ALPINE_LATEST: "3.21"
+  ALPINE_LATEST: "3.22"
   DEBIAN_LATEST: "bookworm"
   UBUNTU_LATEST: "20.4"
   RASPBIAN_LATEST: "bullseye"
@@ -71,7 +71,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson(needs.init.outputs.architectures_alpine) }}
-        version: ["3.18", "3.19", "3.20", "3.21"]
+        version: ["3.19", "3.20", "3.21", "3.22"]
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4.2.2
@@ -249,7 +249,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson(needs.init.outputs.architectures_alpine) }}
-        version: ["3.19", "3.20", "3.21"]
+        version: ["3.20", "3.21", "3.22"]
         python: ["3.11", "3.12", "3.13"]
     steps:
       - name: Checkout the repository

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -249,7 +249,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson(needs.init.outputs.architectures_alpine) }}
-        version: ["3.20", "3.21", "3.22"]
+        version: ["3.19", "3.20", "3.21", "3.22"]
         python: ["3.11", "3.12", "3.13"]
     steps:
       - name: Checkout the repository

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ We support version that are not EOL: https://alpinelinux.org/releases/
 
 | Image | OS | Tags | latest |
 |-------|----|------|--------|
-| armhf-base | Alpine | 3.18, 3.19, 3.20, 3.21 | 3.21 |
-| armv7-base | Alpine | 3.18, 3.19, 3.20, 3.21 | 3.21 |
-| aarch64-base | Alpine | 3.18, 3.19, 3.20, 3.21 | 3.21 |
-| amd64-base | Alpine | 3.18, 3.19, 3.20, 3.21 | 3.21 |
-| i386-base | Alpine | 3.18, 3.19, 3.20, 3.21 | 3.21 |
+| armhf-base | Alpine | 3.19, 3.20, 3.21, 3.22 | 3.22 |
+| armv7-base | Alpine | 3.19, 3.20, 3.21, 3.22 | 3.22 |
+| aarch64-base | Alpine | 3.19, 3.20, 3.21, 3.22 | 3.22 |
+| amd64-base | Alpine | 3.19, 3.20, 3.21, 3.22 | 3.22 |
+| i386-base | Alpine | 3.19, 3.20, 3.21, 3.22 | 3.22 |
 
 ### jemalloc
 
@@ -29,11 +29,11 @@ We support the latest 3 release with the latest 3 Alpine version.
 
 | Image | OS | Tags | latest |
 |-------|----|------|--------|
-| armhf-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.19, 3.11-alpine3.20, 3.11-alpine3.21, 3.12-alpine3.19, 3.12-alpine3.20, 3.12-alpine3.21, 3.13-alpine3.19, 3.13-alpine3.20, 3.13-alpine3.21 | 3.13-alpine3.21 |
-| armv7-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.19, 3.11-alpine3.20, 3.11-alpine3.21, 3.12-alpine3.19, 3.12-alpine3.20, 3.12-alpine3.21, 3.13-alpine3.19, 3.13-alpine3.20, 3.13-alpine3.21 | 3.13-alpine3.21 |
-| aarch64-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.19, 3.11-alpine3.20, 3.11-alpine3.21, 3.12-alpine3.19, 3.12-alpine3.20, 3.12-alpine3.21, 3.13-alpine3.19, 3.13-alpine3.20, 3.13-alpine3.21 | 3.13-alpine3.21 |
-| amd64-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.19, 3.11-alpine3.20, 3.11-alpine3.21, 3.12-alpine3.19, 3.12-alpine3.20, 3.12-alpine3.21, 3.13-alpine3.19, 3.13-alpine3.20, 3.13-alpine3.21 | 3.13-alpine3.21 |
-| i386-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.19, 3.11-alpine3.20, 3.11-alpine3.21, 3.12-alpine3.19, 3.12-alpine3.20, 3.12-alpine3.21, 3.13-alpine3.19, 3.13-alpine3.20, 3.13-alpine3.21 | 3.13-alpine3.21 |
+| armhf-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.19, 3.11-alpine3.20, 3.11-alpine3.21, 3.11-alpine3.22, 3.12-alpine3.19, 3.12-alpine3.20, 3.12-alpine3.21, 3.12-alpine3.22, 3.13-alpine3.19, 3.13-alpine3.20, 3.13-alpine3.21, 3.13-alpine3.22 | 3.13-alpine3.22 |
+| armv7-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.19, 3.11-alpine3.20, 3.11-alpine3.21, 3.11-alpine3.22, 3.12-alpine3.19, 3.12-alpine3.20, 3.12-alpine3.21, 3.12-alpine3.22, 3.13-alpine3.19, 3.13-alpine3.20, 3.13-alpine3.21, 3.13-alpine3.22 | 3.13-alpine3.22 |
+| aarch64-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.19, 3.11-alpine3.20, 3.11-alpine3.21, 3.11-alpine3.22, 3.12-alpine3.19, 3.12-alpine3.20, 3.12-alpine3.21, 3.12-alpine3.22, 3.13-alpine3.19, 3.13-alpine3.20, 3.13-alpine3.21, 3.13-alpine3.21 | 3.13-alpine3.22 |
+| amd64-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.19, 3.11-alpine3.20, 3.11-alpine3.21, 3.11-alpine3.22, 3.12-alpine3.19, 3.12-alpine3.20, 3.12-alpine3.21, 3.12-alpine3.22, 3.13-alpine3.19, 3.13-alpine3.20, 3.13-alpine3.21, 3.13-alpine3.21 | 3.13-alpine3.22 |
+| i386-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.19, 3.11-alpine3.20, 3.11-alpine3.21, 3.11-alpine3.22, 3.12-alpine3.19, 3.12-alpine3.20, 3.12-alpine3.21, 3.12-alpine3.22, 3.13-alpine3.19, 3.13-alpine3.20, 3.13-alpine3.21, 3.13-alpine3.22 | 3.13-alpine3.22 |
 
 ## Others
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ We support the latest 3 release with the latest 3 Alpine version.
 
 | Image | OS | Tags | latest |
 |-------|----|------|--------|
-| armhf-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.19, 3.11-alpine3.20, 3.11-alpine3.21, 3.11-alpine3.22, 3.12-alpine3.19, 3.12-alpine3.20, 3.12-alpine3.21, 3.12-alpine3.22, 3.13-alpine3.19, 3.13-alpine3.20, 3.13-alpine3.21, 3.13-alpine3.22 | 3.13-alpine3.22 |
-| armv7-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.19, 3.11-alpine3.20, 3.11-alpine3.21, 3.11-alpine3.22, 3.12-alpine3.19, 3.12-alpine3.20, 3.12-alpine3.21, 3.12-alpine3.22, 3.13-alpine3.19, 3.13-alpine3.20, 3.13-alpine3.21, 3.13-alpine3.22 | 3.13-alpine3.22 |
-| aarch64-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.19, 3.11-alpine3.20, 3.11-alpine3.21, 3.11-alpine3.22, 3.12-alpine3.19, 3.12-alpine3.20, 3.12-alpine3.21, 3.12-alpine3.22, 3.13-alpine3.19, 3.13-alpine3.20, 3.13-alpine3.21, 3.13-alpine3.21 | 3.13-alpine3.22 |
-| amd64-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.19, 3.11-alpine3.20, 3.11-alpine3.21, 3.11-alpine3.22, 3.12-alpine3.19, 3.12-alpine3.20, 3.12-alpine3.21, 3.12-alpine3.22, 3.13-alpine3.19, 3.13-alpine3.20, 3.13-alpine3.21, 3.13-alpine3.21 | 3.13-alpine3.22 |
-| i386-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.19, 3.11-alpine3.20, 3.11-alpine3.21, 3.11-alpine3.22, 3.12-alpine3.19, 3.12-alpine3.20, 3.12-alpine3.21, 3.12-alpine3.22, 3.13-alpine3.19, 3.13-alpine3.20, 3.13-alpine3.21, 3.13-alpine3.22 | 3.13-alpine3.22 |
+| armhf-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.20, 3.11-alpine3.21, 3.11-alpine3.22, 3.12-alpine3.20, 3.12-alpine3.21, 3.12-alpine3.22, 3.13-alpine3.20, 3.13-alpine3.21, 3.13-alpine3.22 | 3.13-alpine3.22 |
+| armv7-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.20, 3.11-alpine3.21, 3.11-alpine3.22, 3.12-alpine3.20, 3.12-alpine3.21, 3.12-alpine3.22, 3.13-alpine3.20, 3.13-alpine3.21, 3.13-alpine3.22 | 3.13-alpine3.22 |
+| aarch64-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.20, 3.11-alpine3.21, 3.11-alpine3.22, 3.12-alpine3.20, 3.12-alpine3.21, 3.12-alpine3.22, 3.13-alpine3.20, 3.13-alpine3.21, 3.13-alpine3.21 | 3.13-alpine3.22 |
+| amd64-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.20, 3.11-alpine3.21, 3.11-alpine3.22, 3.12-alpine3.20, 3.12-alpine3.21, 3.12-alpine3.22, 3.13-alpine3.20, 3.13-alpine3.21, 3.13-alpine3.21 | 3.13-alpine3.22 |
+| i386-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.20, 3.11-alpine3.21, 3.11-alpine3.22, 3.12-alpine3.20, 3.12-alpine3.21, 3.12-alpine3.22, 3.13-alpine3.20, 3.13-alpine3.21, 3.13-alpine3.22 | 3.13-alpine3.22 |
 
 ## Others
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ We support the latest 3 release with the latest 3 Alpine version.
 
 | Image | OS | Tags | latest |
 |-------|----|------|--------|
-| armhf-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.20, 3.11-alpine3.21, 3.11-alpine3.22, 3.12-alpine3.20, 3.12-alpine3.21, 3.12-alpine3.22, 3.13-alpine3.20, 3.13-alpine3.21, 3.13-alpine3.22 | 3.13-alpine3.22 |
-| armv7-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.20, 3.11-alpine3.21, 3.11-alpine3.22, 3.12-alpine3.20, 3.12-alpine3.21, 3.12-alpine3.22, 3.13-alpine3.20, 3.13-alpine3.21, 3.13-alpine3.22 | 3.13-alpine3.22 |
-| aarch64-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.20, 3.11-alpine3.21, 3.11-alpine3.22, 3.12-alpine3.20, 3.12-alpine3.21, 3.12-alpine3.22, 3.13-alpine3.20, 3.13-alpine3.21, 3.13-alpine3.21 | 3.13-alpine3.22 |
-| amd64-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.20, 3.11-alpine3.21, 3.11-alpine3.22, 3.12-alpine3.20, 3.12-alpine3.21, 3.12-alpine3.22, 3.13-alpine3.20, 3.13-alpine3.21, 3.13-alpine3.21 | 3.13-alpine3.22 |
-| i386-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.20, 3.11-alpine3.21, 3.11-alpine3.22, 3.12-alpine3.20, 3.12-alpine3.21, 3.12-alpine3.22, 3.13-alpine3.20, 3.13-alpine3.21, 3.13-alpine3.22 | 3.13-alpine3.22 |
+| armhf-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.19, 3.11-alpine3.20, 3.11-alpine3.21, 3.12-alpine3.19, 3.12-alpine3.20, 3.12-alpine3.21, 3.13-alpine3.19, 3.13-alpine3.20, 3.13-alpine3.21 | 3.13-alpine3.21 |
+| armv7-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.19, 3.11-alpine3.20, 3.11-alpine3.21, 3.12-alpine3.19, 3.12-alpine3.20, 3.12-alpine3.21, 3.13-alpine3.19, 3.13-alpine3.20, 3.13-alpine3.21 | 3.13-alpine3.21 |
+| aarch64-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.19, 3.11-alpine3.20, 3.11-alpine3.21, 3.12-alpine3.19, 3.12-alpine3.20, 3.12-alpine3.21, 3.13-alpine3.19, 3.13-alpine3.20, 3.13-alpine3.21 | 3.13-alpine3.21 |
+| amd64-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.19, 3.11-alpine3.20, 3.11-alpine3.21, 3.12-alpine3.19, 3.12-alpine3.20, 3.12-alpine3.21, 3.13-alpine3.19, 3.13-alpine3.20, 3.13-alpine3.21 | 3.13-alpine3.21 |
+| i386-base-python | Alpine | 3.11, 3.12, 3.13, 3.11-alpine3.19, 3.11-alpine3.20, 3.11-alpine3.21, 3.12-alpine3.19, 3.12-alpine3.20, 3.12-alpine3.21, 3.13-alpine3.19, 3.13-alpine3.20, 3.13-alpine3.21 | 3.13-alpine3.21 |
 
 ## Others
 


### PR DESCRIPTION
- Alpine 3.22 was released yesterday. https://alpinelinux.org/posts/Alpine-3.22.0-released.html
- Alpine 3.18 reached its EOL last month and is therefore dropped.
