### PR TITLE
Update Python to 3.13.5

### DIFF
--- a/python/3.13/build.yaml
+++ b/python/3.13/build.yaml
@@ -9,7 +9,7 @@ cosign:
   base_identity: https://github.com/home-assistant/docker-base/.*
   identity: https://github.com/home-assistant/docker-base/.*
 args:
-  PYTHON_VERSION: 3.13.4
+  PYTHON_VERSION: 3.13.5
   PIP_VERSION: 25.1.1
   CERT_IDENTITY: thomas@python.org
   CERT_OIDC_ISSUER: https://accounts.google.com


### PR DESCRIPTION
For details see [3.13.5 release announcement](https://discuss.python.org/t/python-3-13-5-is-now-available-yes-really/95211) in Python community.