### PR TITLE
Remove debian bullseye images

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -247,6 +247,7 @@ jobs:
       id-token: write
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         arch: ${{ fromJson(needs.init.outputs.architectures_alpine) }}
         version: ["3.20", "3.21", "3.22"]

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -11,7 +11,7 @@ env:
   ALPINE_LATEST: "3.22"
   DEBIAN_LATEST: "bookworm"
   UBUNTU_LATEST: "20.4"
-  RASPBIAN_LATEST: "bullseye"
+  RASPBIAN_LATEST: "bookworm"
   PYTHON_LATEST: "3.13"
 
 jobs:
@@ -115,7 +115,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson(needs.init.outputs.architectures_debian) }}
-        version: ["bullseye", "bookworm"]
+        version: ["bookworm"]
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4.2.2
@@ -204,7 +204,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson(needs.init.outputs.architectures_raspbian) }}
-        version: ["bullseye", "bookworm"]
+        version: ["bookworm"]
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4.2.2

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ We support the latest 3 release with the latest 3 Alpine version.
 
 | Image | OS | Tags | latest |
 |-------|----|------|--------|
-| armv7-base-debian | Debian | bullseye, bookworm | bookworm |
-| armhf-base-debian | Debian | bullseye, bookworm | bookworm |
-| aarch64-base-debian | Debian | bullseye, bookworm | bookworm |
-| amd64-base-debian | Debian | bullseye, bookworm | bookworm |
-| i386-base-debian | Debian | bullseye, bookworm | bookworm |
+| armv7-base-debian | Debian | bookworm | bookworm |
+| armhf-base-debian | Debian | bookworm | bookworm |
+| aarch64-base-debian | Debian | bookworm | bookworm |
+| amd64-base-debian | Debian | bookworm | bookworm |
+| i386-base-debian | Debian | bookworm | bookworm |
 
 ### Ubuntu images
 
@@ -64,4 +64,4 @@ We support the latest 3 release with the latest 3 Alpine version.
 
 | Image | OS | Tags | latest |
 |-------|----|------|--------|
-| armhf-base-raspbian | Raspbian | bullseye, bookworm | bullseye |
+| armhf-base-raspbian | Raspbian | bookworm | bookworm |


### PR DESCRIPTION
Followup to suggestion from @agners in https://github.com/home-assistant/docker-base/pull/306#issuecomment-3154753680

The debian bullseye armhf image builds started failing recently. For details see: https://github.com/home-assistant/docker-base/pull/306#issuecomment-3148364891.
https://github.com/home-assistant/docker-base/actions/runs/16666794583/job/47238514730?pr=306#step:5:491

--
Also added `fail-fast: false` to Python image builds to make restarting flaky builds easier.