### PR TITLE
Fix typo in builder.yml Ubuntu 20.4 no such version

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -10,7 +10,7 @@ env:
   BUILD_TYPE: base
   ALPINE_LATEST: "3.22"
   DEBIAN_LATEST: "bookworm"
-  UBUNTU_LATEST: "20.4"
+  UBUNTU_LATEST: "20.04"
   RASPBIAN_LATEST: "bookworm"
   PYTHON_LATEST: "3.13"
 


### PR DESCRIPTION
Looks like typo to me, "20.4" should be 20.04?