### PR TITLE
Update Bashio to v0.17.2

### DIFF
--- a/alpine/build.yaml
+++ b/alpine/build.yaml
@@ -8,7 +8,7 @@ build_from:
 cosign:
   identity: https://github.com/home-assistant/docker-base/.*
 args:
-  BASHIO_VERSION: 0.17.0
+  BASHIO_VERSION: 0.17.2
   TEMPIO_VERSION: 2024.11.2
   S6_OVERLAY_VERSION: 3.1.6.2
   JEMALLOC_VERSION: 5.3.0

--- a/debian/build.yaml
+++ b/debian/build.yaml
@@ -8,7 +8,7 @@ build_from:
 cosign:
   identity: https://github.com/home-assistant/docker-base/.*
 args:
-  BASHIO_VERSION: 0.17.0
+  BASHIO_VERSION: 0.17.2
   TEMPIO_VERSION: 2024.11.2
   S6_OVERLAY_VERSION: 3.1.6.2
 labels:

--- a/raspbian/build.yaml
+++ b/raspbian/build.yaml
@@ -4,7 +4,7 @@ build_from:
 cosign:
   identity: https://github.com/home-assistant/docker-base/.*
 args:
-  BASHIO_VERSION: 0.17.0
+  BASHIO_VERSION: 0.17.2
   TEMPIO_VERSION: 2024.11.2
   S6_OVERLAY_VERSION: 3.1.6.2
 labels:

--- a/ubuntu/build.yaml
+++ b/ubuntu/build.yaml
@@ -6,7 +6,7 @@ build_from:
 cosign:
   identity: https://github.com/home-assistant/docker-base/.*
 args:
-  BASHIO_VERSION: 0.17.0
+  BASHIO_VERSION: 0.17.2
   TEMPIO_VERSION: 2024.11.2
   S6_OVERLAY_VERSION: 3.1.6.2
 labels:


### PR DESCRIPTION
Changes:
* https://github.com/hassio-addons/bashio/releases/tag/v0.17.1
* https://github.com/hassio-addons/bashio/releases/tag/v0.17.2

Most notable change is that logging functions now use stdout instead of stderr.