### PR TITLE
apk add gettext-base for Python Dockerfile envsubst usage

### DIFF
--- a/python/3.12/Dockerfile
+++ b/python/3.12/Dockerfile
@@ -23,6 +23,7 @@ RUN \
     && export PYTHON_VERSION=${PYTHON_VERSION} \
     && apk add --no-cache --virtual .fetch-deps \
         cosign \
+        gettext-base \
         openssl \
         tar \
         xz \

--- a/python/3.13/Dockerfile
+++ b/python/3.13/Dockerfile
@@ -19,6 +19,7 @@ RUN \
     && export PYTHON_VERSION=${PYTHON_VERSION} \
     && apk add --no-cache --virtual .fetch-deps \
         cosign \
+        gettext-base \
         openssl \
         tar \
         xz \

--- a/python/3.14/Dockerfile
+++ b/python/3.14/Dockerfile
@@ -19,6 +19,7 @@ RUN \
     && export PYTHON_VERSION=${PYTHON_VERSION} \
     && apk add --no-cache --virtual .fetch-deps \
         cosign \
+        gettext-base \
         openssl \
         tar \
         xz \


### PR DESCRIPTION
GHA build of Python image may fail due to missing envsubst provided by gettext-base distro package. Let's install gettext-base for the build so avoiding the following error when the runner does not install that dependency automatically:
   Run #!/bin/bash
   /home/runner/_work/_temp/95e290b8-e4f0-4605-a1b7-4556cbcad1da.sh: line 3: envsubst: command not found
   Error: Process completed with exit code 127.