### PR TITLE
Flatten base images, modernize the build

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -74,10 +74,10 @@ ADD --unpack=true "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VER
 
 WORKDIR /usr/src/bashio
 
+# Install bashio
 RUN \
     mv /usr/src/bashio/bashio-*/lib /usr/lib/bashio \
-    && ln -s /usr/lib/bashio/bashio /usr/bin/bashio \
-    && rm -rf /usr/src/bashio
+    && ln -s /usr/lib/bashio/bashio /usr/bin/bashio
 
 # Arch-specific downloads (tempio and s6-overlay)
 RUN \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,32 +1,56 @@
 ARG BASE_IMAGE=alpine
 ARG ALPINE_VERSION=3.23
 ARG BUILD_FROM=${BASE_IMAGE}:${ALPINE_VERSION}
-FROM ${BUILD_FROM} AS build
+FROM ${BUILD_FROM} AS jemalloc-build
 
 ENV LANG="C.UTF-8"
 
-# Set shell
-SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+SHELL ["/bin/ash", "-o", "pipefail", "-x", "-c"]
 
-ARG TARGETARCH
-ARG BASHIO_VERSION=0.17.5
-ARG TEMPIO_VERSION=2024.11.2
-ARG S6_OVERLAY_VERSION=3.2.2.0
 ARG JEMALLOC_VERSION=5.3.0
 
-WORKDIR /usr/src
+# jemmalloc
+WORKDIR /usr/src/jemalloc
+
+ADD "https://github.com/jemalloc/jemalloc.git#${JEMALLOC_VERSION}" /usr/src/jemalloc
 
 RUN \
-    set -x \
-    && if [ -z "${TARGETARCH}" ]; then \
-            echo "TARGETARCH is not set, please use Docker BuildKit for the build." && exit 1; \
-        fi \
-    && case "${TARGETARCH}" in \
-            amd64) TEMPIO_ARCH="amd64"; S6_ARCH="x86_64" ;; \
-            arm64) TEMPIO_ARCH="aarch64"; S6_ARCH="aarch64" ;; \
-            *) echo "Unsupported TARGETARCH: ${TARGETARCH}" && exit 1 ;; \
-        esac \
-    && apk add --no-cache \
+    apk add --no-cache --virtual .build-deps \
+        build-base \
+        autoconf \
+        git \
+    && ./autogen.sh \
+        --with-lg-page=16 \
+    && make -j "$(nproc)" \
+    && make install_lib_shared install_bin \
+    && apk del .build-deps \
+    && rm -rf /usr/src/*
+
+############################
+# Intermediary merge image #
+############################
+
+FROM ${BUILD_FROM} AS merge
+
+SHELL ["/bin/ash", "-o", "pipefail", "-x", "-c"]
+
+ARG S6_OVERLAY_VERSION=3.2.2.0
+ARG BASHIO_VERSION=0.17.5
+ARG TEMPIO_VERSION=2024.11.2
+
+# Sanity check for later steps
+ARG TARGETARCH
+RUN \
+    if [ -z "${TARGETARCH}" ]; then \
+        echo "TARGETARCH is not set, please use Docker BuildKit for the build." && exit 1; \
+    fi
+
+# Content created in the build stage
+COPY --link --from=jemalloc-build / /
+
+# Base system packages
+RUN \
+    apk add --no-cache \
         bash \
         bind-tools \
         ca-certificates \
@@ -34,44 +58,41 @@ RUN \
         jq \
         libstdc++ \
         tzdata \
-        xz \
-    \
-    && apk add --no-cache --virtual .build-deps \
-        build-base \
-        autoconf \
-        git \
-    \
+        xz
+
+# S6-Overlay
+ADD --unpack=true "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" /
+ADD --unpack=true "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" /
+ADD --unpack=true "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" /
+
+# bashio
+ADD --unpack=true "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" /usr/src/bashio
+
+WORKDIR /usr/src/bashio
+
+RUN \
+    mv /usr/src/bashio/bashio-*/lib /usr/lib/bashio \
+    && ln -s /usr/lib/bashio/bashio /usr/bin/bashio \
+    && rm -rf /usr/src/bashio
+
+# Arch-specific downloads (tempio and s6-overlay)
+RUN \
+    case "${TARGETARCH}" in \
+        amd64) TEMPIO_ARCH="amd64"; S6_ARCH="x86_64" ;; \
+        arm64) TEMPIO_ARCH="aarch64"; S6_ARCH="aarch64" ;; \
+        *) echo "Unsupported TARGETARCH: ${TARGETARCH}" && exit 1 ;; \
+    esac \
     && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
         | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
-        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
-        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
-        | tar Jxvf - -C / \
-    && mkdir -p /etc/fix-attrs.d \
-    && mkdir -p /etc/services.d \
-    \
-    && git clone "https://github.com/jemalloc/jemalloc" /usr/src/jemalloc \
-    && cd /usr/src/jemalloc \
-    && git checkout ${JEMALLOC_VERSION} \
-    && ./autogen.sh \
-        --with-lg-page=16 \
-    && make -j "$(nproc)" \
-    && make install_lib_shared install_bin \
-    \
-    && mkdir -p /usr/src/bashio \
-    && curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
-        | tar -xzf - --strip 1 -C /usr/src/bashio \
-    && mv /usr/src/bashio/lib /usr/lib/bashio \
-    && ln -s /usr/lib/bashio/bashio /usr/bin/bashio \
-    \
     && curl -L -f -s -o /usr/bin/tempio \
         "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${TEMPIO_ARCH}" \
-    && chmod a+x /usr/bin/tempio \
-    \
-    && apk del .build-deps \
-    && rm -rf /usr/src/*
+    && chmod a+x /usr/bin/tempio
+
+# Touch-ups and cleanup
+RUN \
+    mkdir -p /etc/fix-attrs.d \
+    && mkdir -p /etc/services.d \
+    && rm -rf /usr/src/bashio
 
 # Root filesystem
 COPY rootfs /
@@ -83,8 +104,8 @@ COPY rootfs /
 # Inherit config from the original base image
 FROM ${BUILD_FROM}
 
-# Copy everything from the build
-COPY --from=build / /
+# Copy everything from the merged build
+COPY --from=merge / /
 
 # S6-Overlay entrypoint
 ENTRYPOINT ["/init"]

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,6 +1,11 @@
 ARG BASE_IMAGE=alpine
 ARG ALPINE_VERSION=3.23
 ARG BUILD_FROM=${BASE_IMAGE}:${ALPINE_VERSION}
+
+################
+# Build jemalloc
+################
+
 FROM ${BUILD_FROM} AS jemalloc-build
 
 ENV LANG="C.UTF-8"
@@ -9,7 +14,6 @@ SHELL ["/bin/ash", "-o", "pipefail", "-x", "-c"]
 
 ARG JEMALLOC_VERSION=5.3.0
 
-# jemmalloc
 WORKDIR /usr/src/jemalloc
 
 ADD "https://github.com/jemalloc/jemalloc.git#${JEMALLOC_VERSION}" /usr/src/jemalloc

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -15,7 +15,8 @@ WORKDIR /usr/src/jemalloc
 ADD "https://github.com/jemalloc/jemalloc.git#${JEMALLOC_VERSION}" /usr/src/jemalloc
 
 RUN \
-    apk add --no-cache --virtual .build-deps \
+    --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    apk add --update-cache --virtual .build-deps \
         build-base \
         autoconf \
         git \
@@ -50,7 +51,8 @@ COPY --link --from=jemalloc-build / /
 
 # Base system packages
 RUN \
-    apk add --no-cache \
+    --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    apk add --update-cache \
         bash \
         bind-tools \
         ca-certificates \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,28 +1,20 @@
 ARG BASE_IMAGE=alpine
 ARG ALPINE_VERSION=3.23
 ARG BUILD_FROM=${BASE_IMAGE}:${ALPINE_VERSION}
-FROM ${BUILD_FROM}
+FROM ${BUILD_FROM} AS build
 
-# Default ENV
-ENV \
-    LANG="C.UTF-8" \
-    S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
-    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
-    S6_CMD_WAIT_FOR_SERVICES=1 \
-    S6_SERVICES_READYTIME=50 \
-    UV_EXTRA_INDEX_URL="https://wheels.home-assistant.io/musllinux-index/"
+ENV LANG="C.UTF-8"
 
 # Set shell
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
-
-# Base system
-WORKDIR /usr/src
 
 ARG TARGETARCH
 ARG BASHIO_VERSION=0.17.5
 ARG TEMPIO_VERSION=2024.11.2
 ARG S6_OVERLAY_VERSION=3.2.2.0
 ARG JEMALLOC_VERSION=5.3.0
+
+WORKDIR /usr/src
 
 RUN \
     set -x \
@@ -84,9 +76,30 @@ RUN \
 # Root filesystem
 COPY rootfs /
 
-# S6-Overlay
-WORKDIR /
+#########################
+# Final flattened image #
+#########################
+
+# Inherit config from the original base image
+FROM ${BUILD_FROM}
+
+# Copy everything from the build
+COPY --from=build / /
+
+# S6-Overlay entrypoint
 ENTRYPOINT ["/init"]
+
+# Set shell
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+
+# Default env for S6 and Python/uv
+ENV \
+    LANG="C.UTF-8" \
+    S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_CMD_WAIT_FOR_SERVICES=1 \
+    S6_SERVICES_READYTIME=50 \
+    UV_EXTRA_INDEX_URL="https://wheels.home-assistant.io/musllinux-index/"
 
 LABEL \
     io.hass.type="base" \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -33,6 +33,8 @@ RUN \
 
 FROM ${BUILD_FROM} AS merge
 
+ENV LANG="C.UTF-8"
+
 SHELL ["/bin/ash", "-o", "pipefail", "-x", "-c"]
 
 ARG S6_OVERLAY_VERSION=3.2.2.0

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE=debian
 ARG DEBIAN_VERSION=trixie
 ARG BUILD_FROM=${BASE_IMAGE}:${DEBIAN_VERSION}-slim
-FROM ${BUILD_FROM}
+FROM ${BUILD_FROM} AS build
 
 # Default ENV
 ENV \
@@ -67,9 +67,31 @@ RUN \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /usr/src/*
 
+#########################
+# Final flattened image #
+#########################
+
+# Inherit config from the original base image
+FROM ${BUILD_FROM}
+
+# Copy everything from the build
+COPY --from=build / /
+
 # S6-Overlay
-WORKDIR /
 ENTRYPOINT ["/init"]
+
+# Set shell
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Default ENV
+ENV \
+    LANG="C.UTF-8" \
+    DEBIAN_FRONTEND="noninteractive" \
+    CURL_CA_BUNDLE="/etc/ssl/certs/ca-certificates.crt" \
+    S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_CMD_WAIT_FOR_SERVICES=1 \
+    S6_SERVICES_READYTIME=50
 
 LABEL \
     io.hass.type="base" \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE=debian
 ARG DEBIAN_VERSION=trixie
 ARG BUILD_FROM=${BASE_IMAGE}:${DEBIAN_VERSION}-slim
-FROM ${BUILD_FROM} AS build
+FROM ${BUILD_FROM} AS merge
 
 # Default ENV
 ENV \
@@ -13,59 +13,63 @@ ENV \
     S6_CMD_WAIT_FOR_SERVICES=1 \
     S6_SERVICES_READYTIME=50
 
-# Set shell
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+SHELL ["/bin/bash", "-o", "pipefail", "-x", "-c"]
 
-# Base system
-WORKDIR /usr/src
-
-ARG TARGETARCH
 ARG BASHIO_VERSION=0.17.5
 ARG TEMPIO_VERSION=2024.11.2
 ARG S6_OVERLAY_VERSION=3.2.2.0
 
+# Sanity check for later steps
+ARG TARGETARCH
 RUN \
-    set -x \
-    && if [ -z "${TARGETARCH}" ]; then \
-            echo "TARGETARCH is not set, please use Docker BuildKit for the build." && exit 1; \
-        fi \
-    && case "${TARGETARCH}" in \
-            amd64) TEMPIO_ARCH="amd64"; S6_ARCH="x86_64" ;; \
-            arm64) TEMPIO_ARCH="aarch64"; S6_ARCH="aarch64" ;; \
-            *) echo "Unsupported TARGETARCH: ${TARGETARCH}" && exit 1 ;; \
-        esac \
-    && apt-get update && apt-get install -y --no-install-recommends \
+    if [ -z "${TARGETARCH}" ]; then \
+        echo "TARGETARCH is not set, please use Docker BuildKit for the build." && exit 1; \
+    fi
+
+# Base system packages
+RUN \
+    apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \
         tzdata \
         curl \
         ca-certificates \
         xz-utils \
-    && mkdir -p /usr/share/man/man1 \
-    \
+    && mkdir -p /usr/share/man/man1
+
+# S6-Overlay
+ADD --unpack=true "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" /
+ADD --unpack=true "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" /
+ADD --unpack=true "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" /
+
+# bashio
+ADD --unpack=true "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" /usr/src/bashio
+
+WORKDIR /usr/src/bashio
+
+RUN \
+    mv /usr/src/bashio/bashio-*/lib /usr/lib/bashio \
+    && ln -s /usr/lib/bashio/bashio /usr/bin/bashio \
+    && rm -rf /usr/src/bashio
+
+# Arch-specific downloads (tempio and s6-overlay)
+RUN \
+    case "${TARGETARCH}" in \
+        amd64) TEMPIO_ARCH="amd64"; S6_ARCH="x86_64" ;; \
+        arm64) TEMPIO_ARCH="aarch64"; S6_ARCH="aarch64" ;; \
+        *) echo "Unsupported TARGETARCH: ${TARGETARCH}" && exit 1 ;; \
+    esac \
     && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
         | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
-        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
-        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
-        | tar Jxvf - -C / \
-    && mkdir -p /etc/fix-attrs.d \
-    && mkdir -p /etc/services.d \
-    \
     && curl -L -f -s -o /usr/bin/tempio \
         "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${TEMPIO_ARCH}" \
-    && chmod a+x /usr/bin/tempio \
-    \
-    && mkdir -p /usr/src/bashio \
-    && curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
-        | tar -xzf - --strip 1 -C /usr/src/bashio \
-    && mv /usr/src/bashio/lib /usr/lib/bashio \
-    && ln -s /usr/lib/bashio/bashio /usr/bin/bashio \
-    \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /usr/src/*
+    && chmod a+x /usr/bin/tempio
+
+# Touch-ups and cleanup
+RUN \
+    mkdir -p /etc/fix-attrs.d \
+    && mkdir -p /etc/services.d \
+    && rm -rf /var/lib/apt/lists/*
 
 #########################
 # Final flattened image #
@@ -74,8 +78,8 @@ RUN \
 # Inherit config from the original base image
 FROM ${BUILD_FROM}
 
-# Copy everything from the build
-COPY --from=build / /
+# Copy everything from the merged build
+COPY --from=merge / /
 
 # S6-Overlay
 ENTRYPOINT ["/init"]

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -26,8 +26,14 @@ RUN \
         echo "TARGETARCH is not set, please use Docker BuildKit for the build." && exit 1; \
     fi
 
+# Enable APT cache reuse with BuildKit
+RUN \
+    rm -f /etc/apt/apt.conf.d/docker-clean
+
 # Base system packages
 RUN \
+    --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/python/3.12/Dockerfile
+++ b/python/3.12/Dockerfile
@@ -1,23 +1,24 @@
 ARG BASE_IMAGE=ghcr.io/home-assistant/base
 ARG BASE_VERSION=3.23
 ARG BUILD_FROM=${BASE_IMAGE}:${BASE_VERSION}
-FROM ${BUILD_FROM} AS build
+
+####################
+# Get Python sources
+####################
+
+FROM ${BUILD_FROM} AS python-source
 
 ARG PYTHON_VERSION=3.12.13
 ARG CERT_IDENTITY=thomas@python.org
 ARG CERT_OIDC_ISSUER=https://accounts.google.com
 
-# ensure local python is preferred over distribution python
-ENV PATH=/usr/local/bin:$PATH
+SHELL ["/bin/ash", "-o", "pipefail", "-x", "-c"]
 
-# Set shell
-SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+WORKDIR /tmp/python-fetch
 
+# Fetch and verify Python sources
 RUN \
-    --mount=type=bind,source=./patches,target=/usr/src/patches \
-    set -ex \
-    && export PYTHON_VERSION=${PYTHON_VERSION} \
-    && apk add --no-cache --virtual .fetch-deps \
+    apk add --no-cache --virtual .fetch-deps \
         cosign \
         openssl \
         tar \
@@ -32,27 +33,42 @@ RUN \
         python.tar.xz \
     && mkdir -p /usr/src/python \
     && tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
-    && rm python.tar.xz python.tar.xz.sigstore \
-    \
-    && apk add --no-cache --virtual .build-deps  \
-        patch \
+    && apk del .fetch-deps \
+    && rm -rf /tmp/python-fetch
+
+##############
+# Python build
+##############
+
+FROM ${BUILD_FROM} AS build
+
+# Ensure local python is preferred over distribution python
+ENV PATH=/usr/local/bin:$PATH
+
+SHELL ["/bin/ash", "-o", "pipefail", "-x", "-c"]
+
+# Install build dependencies
+RUN \
+    apk add --no-cache --virtual .build-deps \
+        bluez-dev \
+        build-base \
         bzip2-dev \
         coreutils \
         dpkg-dev dpkg \
         expat-dev \
         findutils \
-        build-base \
         gdbm-dev \
         libc-dev \
         libffi-dev \
-        libnsl-dev \
-        openssl \
-        openssl-dev \
         libtirpc-dev \
+        libnsl-dev \
         linux-headers \
         make \
         mpdecimal-dev \
         ncurses-dev \
+        openssl \
+        openssl-dev \
+        patch \
         pax-utils \
         readline-dev \
         sqlite-dev \
@@ -60,12 +76,15 @@ RUN \
         tk \
         tk-dev \
         xz-dev \
-        zlib-dev \
-        bluez-dev \
-    # add build deps before removing fetch deps in case there's overlap
-    && apk del .fetch-deps \
-    \
-    && for i in /usr/src/patches/*.patch; do \
+        zlib-dev
+
+# Copy with link, so installing deps can run in parallel while downloading sources
+COPY --link --from=python-source /usr/src/python /usr/src/python
+
+# Build and install patched Python
+RUN \
+    --mount=type=bind,source=./patches,target=/usr/src/patches \
+    for i in /usr/src/patches/*.patch; do \
         patch -d /usr/src/python -p 1 < "${i}"; done \
     && cd /usr/src/python \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
@@ -87,26 +106,30 @@ RUN \
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
         EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
     && make install \
-    \
-	&& find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec scanelf --needed --nobanner --format '%n#p' '{}' ';' \
-		| tr ',' '\n' \
-		| sort -u \
-		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-		| xargs -rt apk add --no-cache --virtual .python-rundeps \
-	&& apk del .build-deps \
-	\
+    && apk del .build-deps \
+    && rm -rf /usr/src/python
+
+# Search and install runtime dependencies (except tkinter)
+RUN \
+    find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec scanelf --needed --nobanner --format '%n#p' '{}' ';' \
+        | tr ',' '\n' \
+        | sort -u \
+        | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+        | xargs -rt apk add --no-cache --virtual .python-rundeps \
     && find /usr/local -depth \
         \( \
             -type d -a \( -name test -o -name tests \) \
-        \) -exec rm -rf '{}' + \
-    && rm -rf /usr/src/python \
-# make some useful symlinks that are expected to exist
-    && cd /usr/local/bin \
+        \) -exec rm -rf '{}' +
+
+# Make some useful symlinks that are expected to exist
+RUN \
+    cd /usr/local/bin \
     && ln -s idle3 idle \
     && ln -s pydoc3 pydoc \
     && ln -s python3 python \
     && ln -s python3-config python-config
 
+# Install pip
 ARG PIP_VERSION=26.0.1
 
 RUN set -ex; \
@@ -124,7 +147,7 @@ FROM ${BUILD_FROM}
 # Copy everything from the build
 COPY --from=build / /
 
-# ensure local python is preferred over distribution python
+# Ensure local python is preferred over distribution python
 ENV PATH=/usr/local/bin:$PATH
 
 LABEL \

--- a/python/3.12/Dockerfile
+++ b/python/3.12/Dockerfile
@@ -1,11 +1,7 @@
 ARG BASE_IMAGE=ghcr.io/home-assistant/base
 ARG BASE_VERSION=3.23
 ARG BUILD_FROM=${BASE_IMAGE}:${BASE_VERSION}
-FROM ${BUILD_FROM}
-# Redeclare for usage in base image labels
-ARG BASE_IMAGE
-ARG BASE_VERSION
-ARG BUILD_FROM
+FROM ${BUILD_FROM} AS build
 
 ARG PYTHON_VERSION=3.12.13
 ARG CERT_IDENTITY=thomas@python.org
@@ -117,6 +113,19 @@ RUN set -ex; \
     python -m ensurepip --upgrade --default-pip; \
     pip3 install --no-cache-dir --upgrade pip=="${PIP_VERSION}"; \
     pip --version
+
+#########################
+# Final flattened image #
+#########################
+
+# Inherit config from the original base image
+FROM ${BUILD_FROM}
+
+# Copy everything from the build
+COPY --from=build / /
+
+# ensure local python is preferred over distribution python
+ENV PATH=/usr/local/bin:$PATH
 
 LABEL \
     io.hass.type="base" \

--- a/python/3.12/Dockerfile
+++ b/python/3.12/Dockerfile
@@ -16,7 +16,11 @@ SHELL ["/bin/ash", "-o", "pipefail", "-x", "-c"]
 
 WORKDIR /tmp/python-fetch
 
-# Fetch and verify Python sources
+# Fetch Python source and signatures
+ADD "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz" /tmp/python-fetch/python.tar.xz
+ADD "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz.sigstore" /tmp/python-fetch/python.tar.xz.sigstore
+
+# Verify Python sources
 RUN \
     --mount=type=cache,target=/var/cache/apk,sharing=locked \
     apk add --update-cache --virtual .fetch-deps \
@@ -24,8 +28,6 @@ RUN \
         openssl \
         tar \
         xz \
-    && curl -L -o python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
-    && curl -L -o python.tar.xz.sigstore "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.sigstore" \
     && cosign verify-blob \
         --new-bundle-format \
         --certificate-identity "${CERT_IDENTITY}" \

--- a/python/3.12/Dockerfile
+++ b/python/3.12/Dockerfile
@@ -18,7 +18,8 @@ WORKDIR /tmp/python-fetch
 
 # Fetch and verify Python sources
 RUN \
-    apk add --no-cache --virtual .fetch-deps \
+    --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    apk add --update-cache --virtual .fetch-deps \
         cosign \
         openssl \
         tar \
@@ -49,7 +50,8 @@ SHELL ["/bin/ash", "-o", "pipefail", "-x", "-c"]
 
 # Install build dependencies
 RUN \
-    apk add --no-cache --virtual .build-deps \
+    --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    apk add --update-cache --virtual .build-deps \
         bluez-dev \
         build-base \
         bzip2-dev \
@@ -111,11 +113,12 @@ RUN \
 
 # Search and install runtime dependencies (except tkinter)
 RUN \
+    --mount=type=cache,target=/var/cache/apk,sharing=locked \
     find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec scanelf --needed --nobanner --format '%n#p' '{}' ';' \
         | tr ',' '\n' \
         | sort -u \
         | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-        | xargs -rt apk add --no-cache --virtual .python-rundeps \
+        | xargs -rt apk add --update-cache --virtual .python-rundeps \
     && find /usr/local -depth \
         \( \
             -type d -a \( -name test -o -name tests \) \
@@ -132,9 +135,11 @@ RUN \
 # Install pip
 ARG PIP_VERSION=26.0.1
 
-RUN set -ex; \
+RUN \
+    --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    set -ex; \
     python -m ensurepip --upgrade --default-pip; \
-    pip3 install --no-cache-dir --upgrade pip=="${PIP_VERSION}"; \
+    pip3 install --upgrade pip=="${PIP_VERSION}"; \
     pip --version
 
 #########################

--- a/python/3.13/Dockerfile
+++ b/python/3.13/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE=ghcr.io/home-assistant/base
 ARG BASE_VERSION=3.23
 ARG BUILD_FROM=${BASE_IMAGE}:${BASE_VERSION}
-FROM ${BUILD_FROM}
+FROM ${BUILD_FROM} AS build
 
 ARG PYTHON_VERSION=3.13.13
 ARG CERT_IDENTITY=thomas@python.org
@@ -113,6 +113,23 @@ RUN set -ex; \
     python -m ensurepip --upgrade --default-pip; \
     pip3 install --no-cache-dir --upgrade pip=="${PIP_VERSION}"; \
     pip --version
+
+LABEL \
+    io.hass.type="base" \
+    io.hass.base.name="python"
+
+#########################
+# Final flattened image #
+#########################
+
+# Inherit config from the original base image
+FROM ${BUILD_FROM}
+
+# Copy everything from the build
+COPY --from=build / /
+
+# ensure local python is preferred over distribution python
+ENV PATH=/usr/local/bin:$PATH
 
 LABEL \
     io.hass.type="base" \

--- a/python/3.13/Dockerfile
+++ b/python/3.13/Dockerfile
@@ -16,7 +16,11 @@ SHELL ["/bin/ash", "-o", "pipefail", "-x", "-c"]
 
 WORKDIR /tmp/python-fetch
 
-# Fetch and verify Python sources
+# Fetch Python source and signatures
+ADD "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz" /tmp/python-fetch/python.tar.xz
+ADD "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz.sigstore" /tmp/python-fetch/python.tar.xz.sigstore
+
+# Verify Python sources
 RUN \
     --mount=type=cache,target=/var/cache/apk,sharing=locked \
     apk add --update-cache --virtual .fetch-deps \
@@ -24,8 +28,6 @@ RUN \
         openssl \
         tar \
         xz \
-    && curl -L -o python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
-    && curl -L -o python.tar.xz.sigstore "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.sigstore" \
     && cosign verify-blob \
         --new-bundle-format \
         --certificate-identity "${CERT_IDENTITY}" \

--- a/python/3.13/Dockerfile
+++ b/python/3.13/Dockerfile
@@ -1,23 +1,24 @@
 ARG BASE_IMAGE=ghcr.io/home-assistant/base
 ARG BASE_VERSION=3.23
 ARG BUILD_FROM=${BASE_IMAGE}:${BASE_VERSION}
-FROM ${BUILD_FROM} AS build
+
+####################
+# Get Python sources
+####################
+
+FROM ${BUILD_FROM} AS python-source
 
 ARG PYTHON_VERSION=3.13.13
 ARG CERT_IDENTITY=thomas@python.org
 ARG CERT_OIDC_ISSUER=https://accounts.google.com
 
-# ensure local python is preferred over distribution python
-ENV PATH=/usr/local/bin:$PATH
+SHELL ["/bin/ash", "-o", "pipefail", "-x", "-c"]
 
-# Set shell
-SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+WORKDIR /tmp/python-fetch
 
+# Fetch and verify Python sources
 RUN \
-    --mount=type=bind,source=./patches,target=/usr/src/patches \
-    set -ex \
-    && export PYTHON_VERSION=${PYTHON_VERSION} \
-    && apk add --no-cache --virtual .fetch-deps \
+    apk add --no-cache --virtual .fetch-deps \
         cosign \
         openssl \
         tar \
@@ -32,27 +33,42 @@ RUN \
         python.tar.xz \
     && mkdir -p /usr/src/python \
     && tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
-    && rm python.tar.xz python.tar.xz.sigstore \
-    \
-    && apk add --no-cache --virtual .build-deps  \
-        patch \
+    && apk del .fetch-deps \
+    && rm -rf /tmp/python-fetch
+
+##############
+# Python build
+##############
+
+FROM ${BUILD_FROM} AS build
+
+# Ensure local python is preferred over distribution python
+ENV PATH=/usr/local/bin:$PATH
+
+SHELL ["/bin/ash", "-o", "pipefail", "-x", "-c"]
+
+# Install build dependencies
+RUN \
+    apk add --no-cache --virtual .build-deps \
+        bluez-dev \
+        build-base \
         bzip2-dev \
         coreutils \
         dpkg-dev dpkg \
         expat-dev \
         findutils \
-        build-base \
         gdbm-dev \
         libc-dev \
         libffi-dev \
-        libnsl-dev \
-        openssl \
-        openssl-dev \
         libtirpc-dev \
+        libnsl-dev \
         linux-headers \
         make \
         mpdecimal-dev \
         ncurses-dev \
+        openssl \
+        openssl-dev \
+        patch \
         pax-utils \
         readline-dev \
         sqlite-dev \
@@ -60,12 +76,15 @@ RUN \
         tk \
         tk-dev \
         xz-dev \
-        zlib-dev \
-        bluez-dev \
-    # add build deps before removing fetch deps in case there's overlap
-    && apk del .fetch-deps \
-    \
-    && for i in /usr/src/patches/*.patch; do \
+        zlib-dev
+
+# Copy with link, so installing deps can run in parallel while downloading sources
+COPY --link --from=python-source /usr/src/python /usr/src/python
+
+# Build and install patched Python
+RUN \
+    --mount=type=bind,source=./patches,target=/usr/src/patches \
+    for i in /usr/src/patches/*.patch; do \
         patch -d /usr/src/python -p 1 < "${i}"; done \
     && cd /usr/src/python \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
@@ -87,36 +106,36 @@ RUN \
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
         EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" \
     && make install \
-    \
-	&& find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec scanelf --needed --nobanner --format '%n#p' '{}' ';' \
-		| tr ',' '\n' \
-		| sort -u \
-		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-		| xargs -rt apk add --no-cache --virtual .python-rundeps \
-	&& apk del .build-deps \
-	\
+    && apk del .build-deps \
+    && rm -rf /usr/src/python
+
+# Search and install runtime dependencies (except tkinter)
+RUN \
+    find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec scanelf --needed --nobanner --format '%n#p' '{}' ';' \
+        | tr ',' '\n' \
+        | sort -u \
+        | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+        | xargs -rt apk add --no-cache --virtual .python-rundeps \
     && find /usr/local -depth \
         \( \
             -type d -a \( -name test -o -name tests \) \
-        \) -exec rm -rf '{}' + \
-    && rm -rf /usr/src/python \
-# make some useful symlinks that are expected to exist
-    && cd /usr/local/bin \
+        \) -exec rm -rf '{}' +
+
+# Make some useful symlinks that are expected to exist
+RUN \
+    cd /usr/local/bin \
     && ln -s idle3 idle \
     && ln -s pydoc3 pydoc \
     && ln -s python3 python \
     && ln -s python3-config python-config
 
+# Install pip
 ARG PIP_VERSION=26.0.1
 
 RUN set -ex; \
     python -m ensurepip --upgrade --default-pip; \
     pip3 install --no-cache-dir --upgrade pip=="${PIP_VERSION}"; \
     pip --version
-
-LABEL \
-    io.hass.type="base" \
-    io.hass.base.name="python"
 
 #########################
 # Final flattened image #
@@ -128,7 +147,7 @@ FROM ${BUILD_FROM}
 # Copy everything from the build
 COPY --from=build / /
 
-# ensure local python is preferred over distribution python
+# Ensure local python is preferred over distribution python
 ENV PATH=/usr/local/bin:$PATH
 
 LABEL \

--- a/python/3.13/Dockerfile
+++ b/python/3.13/Dockerfile
@@ -18,7 +18,8 @@ WORKDIR /tmp/python-fetch
 
 # Fetch and verify Python sources
 RUN \
-    apk add --no-cache --virtual .fetch-deps \
+    --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    apk add --update-cache --virtual .fetch-deps \
         cosign \
         openssl \
         tar \
@@ -49,7 +50,8 @@ SHELL ["/bin/ash", "-o", "pipefail", "-x", "-c"]
 
 # Install build dependencies
 RUN \
-    apk add --no-cache --virtual .build-deps \
+    --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    apk add --update-cache --virtual .build-deps \
         bluez-dev \
         build-base \
         bzip2-dev \
@@ -111,11 +113,12 @@ RUN \
 
 # Search and install runtime dependencies (except tkinter)
 RUN \
+    --mount=type=cache,target=/var/cache/apk,sharing=locked \
     find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec scanelf --needed --nobanner --format '%n#p' '{}' ';' \
         | tr ',' '\n' \
         | sort -u \
         | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-        | xargs -rt apk add --no-cache --virtual .python-rundeps \
+        | xargs -rt apk add --update-cache --virtual .python-rundeps \
     && find /usr/local -depth \
         \( \
             -type d -a \( -name test -o -name tests \) \
@@ -132,9 +135,11 @@ RUN \
 # Install pip
 ARG PIP_VERSION=26.0.1
 
-RUN set -ex; \
+RUN \
+    --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    set -ex; \
     python -m ensurepip --upgrade --default-pip; \
-    pip3 install --no-cache-dir --upgrade pip=="${PIP_VERSION}"; \
+    pip3 install --upgrade pip=="${PIP_VERSION}"; \
     pip --version
 
 #########################

--- a/python/3.14/Dockerfile
+++ b/python/3.14/Dockerfile
@@ -1,23 +1,24 @@
 ARG BASE_IMAGE=ghcr.io/home-assistant/base
 ARG BASE_VERSION=3.23
 ARG BUILD_FROM=${BASE_IMAGE}:${BASE_VERSION}
-FROM ${BUILD_FROM} AS build
+
+####################
+# Get Python sources
+####################
+
+FROM ${BUILD_FROM} AS python-source
 
 ARG PYTHON_VERSION=3.14.4
 ARG CERT_IDENTITY=hugo@python.org
 ARG CERT_OIDC_ISSUER=https://github.com/login/oauth
 
-# ensure local python is preferred over distribution python
-ENV PATH=/usr/local/bin:$PATH
+SHELL ["/bin/ash", "-o", "pipefail", "-x", "-c"]
 
-# Set shell
-SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+WORKDIR /tmp/python-fetch
 
+# Fetch and verify Python sources
 RUN \
-    --mount=type=bind,source=./patches,target=/usr/src/patches \
-    set -ex \
-    && export PYTHON_VERSION=${PYTHON_VERSION} \
-    && apk add --no-cache --virtual .fetch-deps \
+    apk add --no-cache --virtual .fetch-deps \
         cosign \
         openssl \
         tar \
@@ -32,27 +33,42 @@ RUN \
         python.tar.xz \
     && mkdir -p /usr/src/python \
     && tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
-    && rm python.tar.xz python.tar.xz.sigstore \
-    \
-    && apk add --no-cache --virtual .build-deps  \
-        patch \
+    && apk del .fetch-deps \
+    && rm -rf /tmp/python-fetch
+
+##############
+# Python build
+##############
+
+FROM ${BUILD_FROM} AS build
+
+# Ensure local python is preferred over distribution python
+ENV PATH=/usr/local/bin:$PATH
+
+SHELL ["/bin/ash", "-o", "pipefail", "-x", "-c"]
+
+# Install build dependencies
+RUN \
+    apk add --no-cache --virtual .build-deps \
+        bluez-dev \
+        build-base \
         bzip2-dev \
         coreutils \
         dpkg-dev dpkg \
         expat-dev \
         findutils \
-        build-base \
         gdbm-dev \
         libc-dev \
         libffi-dev \
-        libnsl-dev \
-        openssl \
-        openssl-dev \
         libtirpc-dev \
+        libnsl-dev \
         linux-headers \
         make \
         mpdecimal-dev \
         ncurses-dev \
+        openssl \
+        openssl-dev \
+        patch \
         pax-utils \
         readline-dev \
         sqlite-dev \
@@ -60,12 +76,15 @@ RUN \
         tk \
         tk-dev \
         xz-dev \
-        zlib-dev \
-        bluez-dev \
-    # add build deps before removing fetch deps in case there's overlap
-    && apk del .fetch-deps \
-    \
-    && for i in /usr/src/patches/*.patch; do \
+        zlib-dev
+
+# Copy with link, so installing deps can run in parallel while downloading sources
+COPY --link --from=python-source /usr/src/python /usr/src/python
+
+# Build and install patched Python
+RUN \
+    --mount=type=bind,source=./patches,target=/usr/src/patches \
+    for i in /usr/src/patches/*.patch; do \
         patch -d /usr/src/python -p 1 < "${i}"; done \
     && cd /usr/src/python \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
@@ -88,26 +107,30 @@ RUN \
 # https://github.com/alpinelinux/aports/commit/675f1babb7ac89068d32b8f4b4e8bbfbb04c96ac
         EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x200000" \
     && make install \
-    \
-	&& find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec scanelf --needed --nobanner --format '%n#p' '{}' ';' \
-		| tr ',' '\n' \
-		| sort -u \
-		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-		| xargs -rt apk add --no-cache --virtual .python-rundeps \
-	&& apk del .build-deps \
-	\
+    && apk del .build-deps \
+    && rm -rf /usr/src/python
+
+# Search and install runtime dependencies (except tkinter)
+RUN \
+    find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec scanelf --needed --nobanner --format '%n#p' '{}' ';' \
+        | tr ',' '\n' \
+        | sort -u \
+        | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+        | xargs -rt apk add --no-cache --virtual .python-rundeps \
     && find /usr/local -depth \
         \( \
             -type d -a \( -name test -o -name tests \) \
-        \) -exec rm -rf '{}' + \
-    && rm -rf /usr/src/python \
-# make some useful symlinks that are expected to exist
-    && cd /usr/local/bin \
+        \) -exec rm -rf '{}' +
+
+# Make some useful symlinks that are expected to exist
+RUN \
+    cd /usr/local/bin \
     && ln -s idle3 idle \
     && ln -s pydoc3 pydoc \
     && ln -s python3 python \
     && ln -s python3-config python-config
 
+# Install pip
 ARG PIP_VERSION=26.0.1
 
 RUN set -ex; \
@@ -125,7 +148,7 @@ FROM ${BUILD_FROM}
 # Copy everything from the build
 COPY --from=build / /
 
-# ensure local python is preferred over distribution python
+# Ensure local python is preferred over distribution python
 ENV PATH=/usr/local/bin:$PATH
 
 LABEL \

--- a/python/3.14/Dockerfile
+++ b/python/3.14/Dockerfile
@@ -16,7 +16,11 @@ SHELL ["/bin/ash", "-o", "pipefail", "-x", "-c"]
 
 WORKDIR /tmp/python-fetch
 
-# Fetch and verify Python sources
+# Fetch Python source and signatures
+ADD "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz" /tmp/python-fetch/python.tar.xz
+ADD "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz.sigstore" /tmp/python-fetch/python.tar.xz.sigstore
+
+# Verify Python sources
 RUN \
     --mount=type=cache,target=/var/cache/apk,sharing=locked \
     apk add --update-cache --virtual .fetch-deps \
@@ -24,8 +28,6 @@ RUN \
         openssl \
         tar \
         xz \
-    && curl -L -o python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
-    && curl -L -o python.tar.xz.sigstore "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.sigstore" \
     && cosign verify-blob \
         --new-bundle-format \
         --certificate-identity "${CERT_IDENTITY}" \

--- a/python/3.14/Dockerfile
+++ b/python/3.14/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE=ghcr.io/home-assistant/base
 ARG BASE_VERSION=3.23
 ARG BUILD_FROM=${BASE_IMAGE}:${BASE_VERSION}
-FROM ${BUILD_FROM}
+FROM ${BUILD_FROM} AS build
 
 ARG PYTHON_VERSION=3.14.4
 ARG CERT_IDENTITY=hugo@python.org
@@ -114,6 +114,19 @@ RUN set -ex; \
     python -m ensurepip --upgrade --default-pip; \
     pip3 install --no-cache-dir --upgrade pip=="${PIP_VERSION}"; \
     pip --version
+
+#########################
+# Final flattened image #
+#########################
+
+# Inherit config from the original base image
+FROM ${BUILD_FROM}
+
+# Copy everything from the build
+COPY --from=build / /
+
+# ensure local python is preferred over distribution python
+ENV PATH=/usr/local/bin:$PATH
 
 LABEL \
     io.hass.type="base" \

--- a/python/3.14/Dockerfile
+++ b/python/3.14/Dockerfile
@@ -18,7 +18,8 @@ WORKDIR /tmp/python-fetch
 
 # Fetch and verify Python sources
 RUN \
-    apk add --no-cache --virtual .fetch-deps \
+    --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    apk add --update-cache --virtual .fetch-deps \
         cosign \
         openssl \
         tar \
@@ -49,7 +50,8 @@ SHELL ["/bin/ash", "-o", "pipefail", "-x", "-c"]
 
 # Install build dependencies
 RUN \
-    apk add --no-cache --virtual .build-deps \
+    --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    apk add --update-cache --virtual .build-deps \
         bluez-dev \
         build-base \
         bzip2-dev \
@@ -112,11 +114,12 @@ RUN \
 
 # Search and install runtime dependencies (except tkinter)
 RUN \
+    --mount=type=cache,target=/var/cache/apk,sharing=locked \
     find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec scanelf --needed --nobanner --format '%n#p' '{}' ';' \
         | tr ',' '\n' \
         | sort -u \
         | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-        | xargs -rt apk add --no-cache --virtual .python-rundeps \
+        | xargs -rt apk add --update-cache --virtual .python-rundeps \
     && find /usr/local -depth \
         \( \
             -type d -a \( -name test -o -name tests \) \
@@ -133,9 +136,11 @@ RUN \
 # Install pip
 ARG PIP_VERSION=26.0.1
 
-RUN set -ex; \
+RUN \
+    --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    set -ex; \
     python -m ensurepip --upgrade --default-pip; \
-    pip3 install --no-cache-dir --upgrade pip=="${PIP_VERSION}"; \
+    pip3 install --upgrade pip=="${PIP_VERSION}"; \
     pip --version
 
 #########################

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -21,8 +21,14 @@ RUN \
         echo "TARGETARCH is not set, please use Docker BuildKit for the build." && exit 1; \
     fi
 
+# Enable APT cache reuse with BuildKit
+RUN \
+    rm -f /etc/apt/apt.conf.d/docker-clean
+
 # Base system packages
 RUN \
+    --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -1,16 +1,12 @@
 ARG BASE_IMAGE=ubuntu
 ARG UBUNTU_VERSION=24.04
 ARG BUILD_FROM=${BASE_IMAGE}:${UBUNTU_VERSION}
-FROM ${BUILD_FROM}
+FROM ${BUILD_FROM} AS build
 
 # Default ENV
 ENV \
     LANG="C.UTF-8" \
-    DEBIAN_FRONTEND="noninteractive" \
-    S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
-    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
-    S6_CMD_WAIT_FOR_SERVICES=1 \
-    S6_SERVICES_READYTIME=50
+    DEBIAN_FRONTEND="noninteractive"
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -65,9 +61,30 @@ RUN \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /usr/src/*
 
+#########################
+# Final flattened image #
+#########################
+
+# Inherit config from the original base image
+FROM ${BUILD_FROM}
+
+# Copy everything from the build
+COPY --from=build / /
+
 # S6-Overlay
-WORKDIR /
 ENTRYPOINT ["/init"]
+
+# Set shell
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Default ENV
+ENV \
+    LANG="C.UTF-8" \
+    DEBIAN_FRONTEND="noninteractive" \
+    S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_CMD_WAIT_FOR_SERVICES=1 \
+    S6_SERVICES_READYTIME=50
 
 LABEL \
     io.hass.type="base" \

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -1,65 +1,69 @@
 ARG BASE_IMAGE=ubuntu
 ARG UBUNTU_VERSION=24.04
 ARG BUILD_FROM=${BASE_IMAGE}:${UBUNTU_VERSION}
-FROM ${BUILD_FROM} AS build
+FROM ${BUILD_FROM} AS merge
 
 # Default ENV
 ENV \
     LANG="C.UTF-8" \
     DEBIAN_FRONTEND="noninteractive"
 
-# Set shell
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+SHELL ["/bin/bash", "-o", "pipefail", "-x", "-c"]
 
-# Base system
-WORKDIR /usr/src
-
-ARG TARGETARCH
 ARG BASHIO_VERSION=0.17.5
 ARG TEMPIO_VERSION=2024.11.2
 ARG S6_OVERLAY_VERSION=3.2.2.0
 
+# Sanity check for later steps
+ARG TARGETARCH
 RUN \
-    set -x \
-    && if [ -z "${TARGETARCH}" ]; then \
-            echo "TARGETARCH is not set, please use Docker BuildKit for the build." && exit 1; \
-        fi \
-    && case "${TARGETARCH}" in \
-            amd64) TEMPIO_ARCH="amd64"; S6_ARCH="x86_64" ;; \
-            arm64) TEMPIO_ARCH="aarch64"; S6_ARCH="aarch64" ;; \
-            *) echo "Unsupported TARGETARCH: ${TARGETARCH}" && exit 1 ;; \
-        esac \
-    && apt-get update && apt-get install -y --no-install-recommends \
+    if [ -z "${TARGETARCH}" ]; then \
+        echo "TARGETARCH is not set, please use Docker BuildKit for the build." && exit 1; \
+    fi
+
+# Base system packages
+RUN \
+    apt-get update && apt-get install -y --no-install-recommends \
         bash \
         jq \
         tzdata \
         curl \
         ca-certificates \
-        xz-utils \
-    \
+        xz-utils
+
+# S6-Overlay
+ADD --unpack=true "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" /
+ADD --unpack=true "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" /
+ADD --unpack=true "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" /
+
+# bashio
+ADD --unpack=true "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" /usr/src/bashio
+
+WORKDIR /usr/src/bashio
+
+RUN \
+    mv /usr/src/bashio/bashio-*/lib /usr/lib/bashio \
+    && ln -s /usr/lib/bashio/bashio /usr/bin/bashio \
+    && rm -rf /usr/src/bashio
+
+# Arch-specific downloads (tempio and s6-overlay)
+RUN \
+    case "${TARGETARCH}" in \
+        amd64) TEMPIO_ARCH="amd64"; S6_ARCH="x86_64" ;; \
+        arm64) TEMPIO_ARCH="aarch64"; S6_ARCH="aarch64" ;; \
+        *) echo "Unsupported TARGETARCH: ${TARGETARCH}" && exit 1 ;; \
+    esac \
     && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
         | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
-        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
-        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
-        | tar Jxvf - -C / \
-    && mkdir -p /etc/fix-attrs.d \
-    && mkdir -p /etc/services.d \
-    \
     && curl -L -f -s -o /usr/bin/tempio \
         "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${TEMPIO_ARCH}" \
-    && chmod a+x /usr/bin/tempio \
-    \
-    && mkdir -p /usr/src/bashio \
-    && curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
-        | tar -xzf - --strip 1 -C /usr/src/bashio \
-    && mv /usr/src/bashio/lib /usr/lib/bashio \
-    && ln -s /usr/lib/bashio/bashio /usr/bin/bashio \
-    \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /usr/src/*
+    && chmod a+x /usr/bin/tempio
+
+# Touch-ups and cleanup
+RUN \
+    mkdir -p /etc/fix-attrs.d \
+    && mkdir -p /etc/services.d \
+    && rm -rf /var/lib/apt/lists/*
 
 #########################
 # Final flattened image #
@@ -68,8 +72,8 @@ RUN \
 # Inherit config from the original base image
 FROM ${BUILD_FROM}
 
-# Copy everything from the build
-COPY --from=build / /
+# Copy everything from the merged build
+COPY --from=merge / /
 
 # S6-Overlay
 ENTRYPOINT ["/init"]


### PR DESCRIPTION
- Flatten the Alpine, Debian, Ubuntu, and Python images after their build stages so the published images stay lean while preserving the staged build workflow. E.g. `base` images are now only 2 layers (alpine + our changes), `base-python` is 3 layers (our `base` + Python)
- Restructure the distro and Python Dockerfiles to be more BuildKit-friendly by separating source fetches from build steps, switching static remote downloads to cacheable `ADD` where possible, and making the stage layout clearer and more consistent.
- Improve rebuild performance by adding package-manager cache mounts for `apk`, `apt`, and `pip`, and by enabling APT cache reuse in the Debian and Ubuntu builds.

The resulting image content and metadata was verified to be (mostly; e.g. some Alpine packages have been updated in the meantime and Debian/Ubuntu no longer set `WorkDir`) identical to the images before this change.