### PR TITLE
Repository fork friendly distro Dockerfile updates

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -41,8 +41,11 @@ ENV LANG="C.UTF-8"
 
 SHELL ["/bin/ash", "-o", "pipefail", "-x", "-c"]
 
-ARG S6_OVERLAY_VERSION=3.2.2.0
+ARG BASHIO_REPOSITORY=hassio-addons/bashio
 ARG BASHIO_VERSION=0.17.5
+ARG S6_OVERLAY_REPOSITORY=just-containers/s6-overlay
+ARG S6_OVERLAY_VERSION=3.2.2.0
+ARG TEMPIO_REPOSITORY=home-assistant/tempio
 ARG TEMPIO_VERSION=2024.11.2
 
 # Sanity check for later steps
@@ -69,12 +72,12 @@ RUN \
         xz
 
 # S6-Overlay
-ADD --unpack=true "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" /
-ADD --unpack=true "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" /
-ADD --unpack=true "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" /
+ADD --unpack=true "https://github.com/${S6_OVERLAY_REPOSITORY}/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" /
+ADD --unpack=true "https://github.com/${S6_OVERLAY_REPOSITORY}/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" /
+ADD --unpack=true "https://github.com/${S6_OVERLAY_REPOSITORY}/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" /
 
 # bashio
-ADD --unpack=true "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" /usr/src/bashio
+ADD --unpack=true "https://github.com/${BASHIO_REPOSITORY}/archive/v${BASHIO_VERSION}.tar.gz" /usr/src/bashio
 
 WORKDIR /usr/src/bashio
 
@@ -90,10 +93,10 @@ RUN \
         arm64) TEMPIO_ARCH="aarch64"; S6_ARCH="aarch64" ;; \
         *) echo "Unsupported TARGETARCH: ${TARGETARCH}" && exit 1 ;; \
     esac \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
+    && curl -L -f -s "https://github.com/${S6_OVERLAY_REPOSITORY}/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
         | tar Jxvf - -C / \
     && curl -L -f -s -o /usr/bin/tempio \
-        "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${TEMPIO_ARCH}" \
+        "https://github.com/${TEMPIO_REPOSITORY}/releases/download/${TEMPIO_VERSION}/tempio_${TEMPIO_ARCH}" \
     && chmod a+x /usr/bin/tempio
 
 # Touch-ups and cleanup

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -43,8 +43,10 @@ SHELL ["/bin/ash", "-o", "pipefail", "-x", "-c"]
 
 ARG BASHIO_REPOSITORY=hassio-addons/bashio
 ARG BASHIO_VERSION=0.17.5
+ARG S6_OVERLAY_ARCH
 ARG S6_OVERLAY_REPOSITORY=just-containers/s6-overlay
 ARG S6_OVERLAY_VERSION=3.2.2.0
+ARG TEMPIO_ARCH
 ARG TEMPIO_REPOSITORY=home-assistant/tempio
 ARG TEMPIO_VERSION=2024.11.2
 
@@ -89,11 +91,18 @@ RUN \
 # Arch-specific downloads (tempio and s6-overlay)
 RUN \
     case "${TARGETARCH}" in \
-        amd64) TEMPIO_ARCH="amd64"; S6_ARCH="x86_64" ;; \
-        arm64) TEMPIO_ARCH="aarch64"; S6_ARCH="aarch64" ;; \
-        *) echo "Unsupported TARGETARCH: ${TARGETARCH}" && exit 1 ;; \
+        amd64) \
+            S6_OVERLAY_ARCH="${S6_OVERLAY_ARCH:-x86_64}" \
+            ;; \
+        arm64) \
+            S6_OVERLAY_ARCH="${S6_OVERLAY_ARCH:-aarch64}" \
+            TEMPIO_ARCH="${TEMPIO_ARCH:-aarch64}" \
+            ;; \
     esac \
-    && curl -L -f -s "https://github.com/${S6_OVERLAY_REPOSITORY}/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
+    && echo "Selected from TARGETARCH=${TARGETARCH} arch-specific" \
+        " S6_OVERLAY_ARCH=${S6_OVERLAY_ARCH:=${TARGETARCH}}" \
+        " TEMPIO_ARCH=${TEMPIO_ARCH:=${TARGETARCH}}" \
+    && curl -L -f -s "https://github.com/${S6_OVERLAY_REPOSITORY}/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_OVERLAY_ARCH}.tar.xz" \
         | tar Jxvf - -C / \
     && curl -L -f -s -o /usr/bin/tempio \
         "https://github.com/${TEMPIO_REPOSITORY}/releases/download/${TEMPIO_VERSION}/tempio_${TEMPIO_ARCH}" \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -15,9 +15,12 @@ ENV \
 
 SHELL ["/bin/bash", "-o", "pipefail", "-x", "-c"]
 
+ARG BASHIO_REPOSITORY=hassio-addons/bashio
 ARG BASHIO_VERSION=0.17.5
-ARG TEMPIO_VERSION=2024.11.2
+ARG S6_OVERLAY_REPOSITORY=just-containers/s6-overlay
 ARG S6_OVERLAY_VERSION=3.2.2.0
+ARG TEMPIO_REPOSITORY=home-assistant/tempio
+ARG TEMPIO_VERSION=2024.11.2
 
 # Sanity check for later steps
 ARG TARGETARCH
@@ -44,12 +47,12 @@ RUN \
     && mkdir -p /usr/share/man/man1
 
 # S6-Overlay
-ADD --unpack=true "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" /
-ADD --unpack=true "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" /
-ADD --unpack=true "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" /
+ADD --unpack=true "https://github.com/${S6_OVERLAY_REPOSITORY}/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" /
+ADD --unpack=true "https://github.com/${S6_OVERLAY_REPOSITORY}/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" /
+ADD --unpack=true "https://github.com/${S6_OVERLAY_REPOSITORY}/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" /
 
 # bashio
-ADD --unpack=true "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" /usr/src/bashio
+ADD --unpack=true "https://github.com/${BASHIO_REPOSITORY}/archive/v${BASHIO_VERSION}.tar.gz" /usr/src/bashio
 
 WORKDIR /usr/src/bashio
 
@@ -65,10 +68,10 @@ RUN \
         arm64) TEMPIO_ARCH="aarch64"; S6_ARCH="aarch64" ;; \
         *) echo "Unsupported TARGETARCH: ${TARGETARCH}" && exit 1 ;; \
     esac \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
+    && curl -L -f -s "https://github.com/${S6_OVERLAY_REPOSITORY}/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
         | tar Jxvf - -C / \
     && curl -L -f -s -o /usr/bin/tempio \
-        "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${TEMPIO_ARCH}" \
+        "https://github.com/${TEMPIO_REPOSITORY}/releases/download/${TEMPIO_VERSION}/tempio_${TEMPIO_ARCH}" \
     && chmod a+x /usr/bin/tempio
 
 # Touch-ups and cleanup

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -17,8 +17,10 @@ SHELL ["/bin/bash", "-o", "pipefail", "-x", "-c"]
 
 ARG BASHIO_REPOSITORY=hassio-addons/bashio
 ARG BASHIO_VERSION=0.17.5
+ARG S6_OVERLAY_ARCH
 ARG S6_OVERLAY_REPOSITORY=just-containers/s6-overlay
 ARG S6_OVERLAY_VERSION=3.2.2.0
+ARG TEMPIO_ARCH
 ARG TEMPIO_REPOSITORY=home-assistant/tempio
 ARG TEMPIO_VERSION=2024.11.2
 
@@ -64,11 +66,18 @@ RUN \
 # Arch-specific downloads (tempio and s6-overlay)
 RUN \
     case "${TARGETARCH}" in \
-        amd64) TEMPIO_ARCH="amd64"; S6_ARCH="x86_64" ;; \
-        arm64) TEMPIO_ARCH="aarch64"; S6_ARCH="aarch64" ;; \
-        *) echo "Unsupported TARGETARCH: ${TARGETARCH}" && exit 1 ;; \
+        amd64) \
+            S6_OVERLAY_ARCH="${S6_OVERLAY_ARCH:-x86_64}" \
+            ;; \
+        arm64) \
+            S6_OVERLAY_ARCH="${S6_OVERLAY_ARCH:-aarch64}" \
+            TEMPIO_ARCH="${TEMPIO_ARCH:-aarch64}" \
+            ;; \
     esac \
-    && curl -L -f -s "https://github.com/${S6_OVERLAY_REPOSITORY}/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
+    && echo "Selected from TARGETARCH=${TARGETARCH} arch-specific" \
+        " S6_OVERLAY_ARCH=${S6_OVERLAY_ARCH:=${TARGETARCH}}" \
+        " TEMPIO_ARCH=${TEMPIO_ARCH:=${TARGETARCH}}" \
+    && curl -L -f -s "https://github.com/${S6_OVERLAY_REPOSITORY}/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_OVERLAY_ARCH}.tar.xz" \
         | tar Jxvf - -C / \
     && curl -L -f -s -o /usr/bin/tempio \
         "https://github.com/${TEMPIO_REPOSITORY}/releases/download/${TEMPIO_VERSION}/tempio_${TEMPIO_ARCH}" \

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -10,9 +10,12 @@ ENV \
 
 SHELL ["/bin/bash", "-o", "pipefail", "-x", "-c"]
 
+ARG BASHIO_REPOSITORY=hassio-addons/bashio
 ARG BASHIO_VERSION=0.17.5
-ARG TEMPIO_VERSION=2024.11.2
+ARG S6_OVERLAY_REPOSITORY=just-containers/s6-overlay
 ARG S6_OVERLAY_VERSION=3.2.2.0
+ARG TEMPIO_REPOSITORY=home-assistant/tempio
+ARG TEMPIO_VERSION=2024.11.2
 
 # Sanity check for later steps
 ARG TARGETARCH
@@ -38,12 +41,12 @@ RUN \
         xz-utils
 
 # S6-Overlay
-ADD --unpack=true "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" /
-ADD --unpack=true "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" /
-ADD --unpack=true "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" /
+ADD --unpack=true "https://github.com/${S6_OVERLAY_REPOSITORY}/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" /
+ADD --unpack=true "https://github.com/${S6_OVERLAY_REPOSITORY}/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" /
+ADD --unpack=true "https://github.com/${S6_OVERLAY_REPOSITORY}/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" /
 
 # bashio
-ADD --unpack=true "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" /usr/src/bashio
+ADD --unpack=true "https://github.com/${BASHIO_REPOSITORY}/archive/v${BASHIO_VERSION}.tar.gz" /usr/src/bashio
 
 WORKDIR /usr/src/bashio
 
@@ -59,10 +62,10 @@ RUN \
         arm64) TEMPIO_ARCH="aarch64"; S6_ARCH="aarch64" ;; \
         *) echo "Unsupported TARGETARCH: ${TARGETARCH}" && exit 1 ;; \
     esac \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
+    && curl -L -f -s "https://github.com/${S6_OVERLAY_REPOSITORY}/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
         | tar Jxvf - -C / \
     && curl -L -f -s -o /usr/bin/tempio \
-        "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${TEMPIO_ARCH}" \
+        "https://github.com/${TEMPIO_REPOSITORY}/releases/download/${TEMPIO_VERSION}/tempio_${TEMPIO_ARCH}" \
     && chmod a+x /usr/bin/tempio
 
 # Touch-ups and cleanup

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -12,8 +12,10 @@ SHELL ["/bin/bash", "-o", "pipefail", "-x", "-c"]
 
 ARG BASHIO_REPOSITORY=hassio-addons/bashio
 ARG BASHIO_VERSION=0.17.5
+ARG S6_OVERLAY_ARCH
 ARG S6_OVERLAY_REPOSITORY=just-containers/s6-overlay
 ARG S6_OVERLAY_VERSION=3.2.2.0
+ARG TEMPIO_ARCH
 ARG TEMPIO_REPOSITORY=home-assistant/tempio
 ARG TEMPIO_VERSION=2024.11.2
 
@@ -57,12 +59,19 @@ RUN \
 
 # Arch-specific downloads (tempio and s6-overlay)
 RUN \
-    case "${TARGETARCH}" in \
-        amd64) TEMPIO_ARCH="amd64"; S6_ARCH="x86_64" ;; \
-        arm64) TEMPIO_ARCH="aarch64"; S6_ARCH="aarch64" ;; \
-        *) echo "Unsupported TARGETARCH: ${TARGETARCH}" && exit 1 ;; \
+      case "${TARGETARCH}" in \
+        amd64) \
+            S6_OVERLAY_ARCH="${S6_OVERLAY_ARCH:-x86_64}" \
+            ;; \
+        arm64) \
+            S6_OVERLAY_ARCH="${S6_OVERLAY_ARCH:-aarch64}" \
+            TEMPIO_ARCH="${TEMPIO_ARCH:-aarch64}" \
+            ;; \
     esac \
-    && curl -L -f -s "https://github.com/${S6_OVERLAY_REPOSITORY}/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
+    && echo "Selected from TARGETARCH=${TARGETARCH} arch-specific" \
+        " S6_OVERLAY_ARCH=${S6_OVERLAY_ARCH:=${TARGETARCH}}" \
+        " TEMPIO_ARCH=${TEMPIO_ARCH:=${TARGETARCH}}" \
+    && curl -L -f -s "https://github.com/${S6_OVERLAY_REPOSITORY}/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_OVERLAY_ARCH}.tar.xz" \
         | tar Jxvf - -C / \
     && curl -L -f -s -o /usr/bin/tempio \
         "https://github.com/${TEMPIO_REPOSITORY}/releases/download/${TEMPIO_VERSION}/tempio_${TEMPIO_ARCH}" \


### PR DESCRIPTION
Parameterize named dependency repository and also the URL component based on TARGETARCH so this can be specified by fork repository workflow in that workflow instead of needing to edit directly the three distro Dockerfile ad. nauseum when developing a port to an unsupported architecture or troubleshooting the workflow for failure modes.

These optional parameters are not normally useful unless CI/CD in a fork of the repository or standalone use is intended.