### PR TITLE
Add Alpine 3.24 base image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,8 +5,8 @@
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick an Alpine version: 3.20, 3.21, 3.22
-		"args": { "VARIANT": "3.22" }
+		// Update 'VARIANT' to pick an Alpine version: 3.22, 3.23, 3.24
+		"args": { "VARIANT": "3.24" }
 	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        alpine_version: ["3.21", "3.22", "3.23"]
+        alpine_version: ["3.21", "3.22", "3.23", "3.24"]
     permissions:
       contents: read
       id-token: write # For cosign signing

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ We support version that are not EOL: https://alpinelinux.org/releases/
 
 | Image | OS | Tags | latest |
 |-------|----|------|--------|
-| base | Alpine | 3.21, 3.22, 3.23 | 3.23 |
+| base | Alpine | 3.21, 3.22, 3.23, 3.24 | 3.23 |
 
 ### jemalloc
 
@@ -70,8 +70,8 @@ To use a specific Alpine base version:
 
 ```bash
 docker buildx build \
-  --build-arg ALPINE_VERSION=3.21 \
-  -t base:3.21 \
+  --build-arg ALPINE_VERSION=3.23 \
+  -t base:3.23 \
   alpine/
 ```
 
@@ -93,12 +93,12 @@ docker buildx build \
   ubuntu/
 ```
 
-Python 3.14 image, using the Home Assistant Alpine 3.23 base image from GHCR:
+Python 3.14 image, using the Home Assistant Alpine 3.24 base image from GHCR:
 
 ```bash
 docker buildx build \
   --build-arg BASE_IMAGE=ghcr.io/home-assistant/base \
-  --build-arg BASE_VERSION=3.23 \
-  -t base-python:3.14-alpine3.23 \
+  --build-arg BASE_VERSION=3.24 \
+  -t base-python:3.14-alpine3.24 \
   python/3.14/
 ```


### PR DESCRIPTION
Add Alpine 3.24 to the build matrix and update the examples. Intentionally not dropping 3.21 yet and separating the bump into base bump and bump in Python images to avoid CI failing because of missing image, or using outdated 3.21 base for a tagged release of the Python base images.

Following merge of this change, a release should be published, which will create base:3.24 image, which can be used for builds of the Python base images. At the same time, we can drop 3.21 and set 3.24 as the latest version.