### PR TITLE
Drop Alpine 3.21, add 3.24 Python variant, use 3.24 as latest

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -11,7 +11,7 @@ on:
 env:
   REGISTRY_PREFIX: ghcr.io/${{ github.repository_owner }}
   ARCHITECTURES: '["amd64", "aarch64"]'
-  ALPINE_LATEST: "3.23"
+  ALPINE_LATEST: "3.24"
   DEBIAN_LATEST: "trixie"
   UBUNTU_LATEST: "24.04"
   PYTHON_LATEST: "3.14"
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        alpine_version: ["3.21", "3.22", "3.23", "3.24"]
+        alpine_version: ["3.22", "3.23", "3.24"]
     permissions:
       contents: read
       id-token: write # For cosign signing
@@ -154,7 +154,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        alpine_version: ["3.21", "3.22", "3.23"]
+        alpine_version: ["3.22", "3.23", "3.24"]
         python_version: ["3.12", "3.13", "3.14"]
     permissions:
       contents: read

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Beginning with the 2026.03.1 release, all images are published as multi-arch ima
 
 ## Base images
 
-We support version that are not EOL: https://alpinelinux.org/releases/
+We support versions that are not EOL: https://alpinelinux.org/releases/
 
 | Image | OS | Tags | latest |
 |-------|----|------|--------|
-| base | Alpine | 3.21, 3.22, 3.23, 3.24 | 3.23 |
+| base | Alpine | 3.22, 3.23, 3.24 | 3.24 |
 
 ### jemalloc
 
@@ -27,11 +27,11 @@ We support on our platforms jemalloc. On the application which you want to enabl
 
 ### Python images
 
-We support the latest 3 release with the latest 3 Alpine version.
+We support the latest 3 releases with the latest 3 Alpine versions.
 
 | Image | OS | Python versions | Tags | latest |
 |-------|----|-----------------|------|--------|
-| base-python | Alpine | 3.12, 3.13, 3.14 | 3.12-alpine3.21, 3.12-alpine3.22, 3.12-alpine3.23, 3.13-alpine3.21, 3.13-alpine3.22, 3.13-alpine3.23, 3.14-alpine3.21, 3.14-alpine3.22, 3.14-alpine3.23 | 3.14-alpine3.23 |
+| base-python | Alpine | 3.12, 3.13, 3.14 | 3.12-alpine3.22, 3.12-alpine3.23, 3.12-alpine3.24, 3.13-alpine3.22, 3.13-alpine3.23, 3.13-alpine3.24, 3.14-alpine3.22, 3.14-alpine3.23, 3.14-alpine3.24 | 3.14-alpine3.24 |
 
 ## Others
 


### PR DESCRIPTION
Drop 3.21 both as the plain base and the 3.21 Python variants. Mark 3.24 as the latest version and use it as base for Python as well.

Also, fix some typos in the readme.