### PR TITLE
python: 3.14: build with clang, lld, ThinLTO, tail-call interpreter and CC set to gcc

### DIFF
--- a/python/3.14/Dockerfile
+++ b/python/3.14/Dockerfile
@@ -58,6 +58,7 @@ RUN \
         build-base \
         bzip2-dev \
         clang \
+        compiler-rt \
         coreutils \
         dpkg-dev dpkg \
         expat-dev \

--- a/python/3.14/Dockerfile
+++ b/python/3.14/Dockerfile
@@ -92,6 +92,7 @@ COPY --link --from=python-source /usr/src/python /usr/src/python
 # Build and install patched Python
 RUN \
     --mount=type=bind,source=./patches,target=/usr/src/patches \
+    --mount=type=bind,source=./normalize-sysconfig.py,target=/usr/src/normalize-sysconfig.py \
     for i in /usr/src/patches/*.patch; do \
         patch -d /usr/src/python -p 1 < "${i}"; done \
     && cd /usr/src/python \
@@ -120,6 +121,9 @@ RUN \
 # https://github.com/alpinelinux/aports/commit/675f1babb7ac89068d32b8f4b4e8bbfbb04c96ac
         EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x200000" \
     && make install \
+# downstream extension builds default to the toolchain recorded in sysconfig,
+# but images based on this one only ship the GNU toolchain (build-base)
+    && python3 /usr/src/normalize-sysconfig.py \
     && apk del .build-deps \
     && rm -rf /usr/src/python
 

--- a/python/3.14/Dockerfile
+++ b/python/3.14/Dockerfile
@@ -57,6 +57,7 @@ RUN \
         bluez-dev \
         build-base \
         bzip2-dev \
+        clang \
         coreutils \
         dpkg-dev dpkg \
         expat-dev \
@@ -67,6 +68,8 @@ RUN \
         libtirpc-dev \
         libnsl-dev \
         linux-headers \
+        lld \
+        llvm \
         make \
         mpdecimal-dev \
         ncurses-dev \
@@ -98,13 +101,18 @@ RUN \
         --enable-optimizations \
         --enable-option-checking=fatal \
         --enable-shared \
-        --with-lto \
+        --with-lto=thin \
         --with-system-libmpdec \
         --with-system-expat \
+        --with-tail-call-interp \
         --without-ensurepip \
         --without-static-libpython \
+        CC=clang \
+        CXX=clang++ \
+        AR=llvm-ar \
+        RANLIB=llvm-ranlib \
     && make -j "$(nproc)" \
-        LDFLAGS="-Wl,--strip-all" \
+        LDFLAGS="-fuse-ld=lld -Wl,--strip-all" \
         CFLAGS="-fno-semantic-interposition" \
 # set thread stack size to 2MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0

--- a/python/3.14/normalize-sysconfig.py
+++ b/python/3.14/normalize-sysconfig.py
@@ -1,0 +1,98 @@
+"""Normalize toolchain references in the installed Python's sysconfig.
+
+CPython records the build-time compiler and linker in _sysconfigdata,
+the installed Makefile and python3.x-config. pip/setuptools default to
+these values when compiling extension modules from source, but images
+downstream only ship the GNU toolchain (apk add build-base). The
+interpreter is built with clang/lld purely for performance; extensions
+built with gcc against it are ABI compatible, so rewrite the recorded
+toolchain back to the GNU defaults.
+
+Modeled after python-build-standalone's hack_sysconfig.py:
+https://github.com/astral-sh/python-build-standalone/blob/main/cpython-unix/build-cpython.sh
+"""
+
+import importlib
+import json
+import os
+import re
+import sys
+import sysconfig
+
+REPLACEMENTS = [
+    (re.compile(r"-fuse-ld=lld\s*"), ""),
+    (re.compile(r"\bclang\+\+"), "g++"),
+    (re.compile(r"\bclang\b"), "gcc"),
+    (re.compile(r"\bllvm-ar\b"), "ar"),
+    (re.compile(r"\bllvm-ranlib\b"), "ranlib"),
+]
+
+
+def normalize(text):
+    for pattern, replacement in REPLACEMENTS:
+        text = pattern.sub(replacement, text)
+    return text
+
+
+def normalize_file(path):
+    with open(path, encoding="utf-8") as fh:
+        data = fh.read()
+
+    normalized = normalize(data)
+    if normalized != data:
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(normalized)
+        print(f"normalized {path}")
+    else:
+        print(f"no changes needed in {path}")
+
+
+def normalize_sysconfigdata():
+    module = importlib.import_module(sysconfig._get_sysconfigdata_name())
+    path = module.__file__
+    build_time_vars = {
+        key: normalize(value) if isinstance(value, str) else value
+        for key, value in module.build_time_vars.items()
+    }
+
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write("# system configuration generated and used by the sysconfig module\n")
+        fh.write(f"build_time_vars = {json.dumps(build_time_vars, indent=4, sort_keys=True)}\n")
+    print(f"normalized {path}")
+
+    return build_time_vars
+
+
+def main():
+    build_time_vars = normalize_sysconfigdata()
+    normalize_file(sysconfig.get_makefile_filename())
+    normalize_file(
+        os.path.join(
+            sysconfig.get_config_var("BINDIR"),
+            f"python{sysconfig.get_config_var('VERSION')}-config",
+        )
+    )
+
+    # keys used by sysconfig.customize_compiler() and python3.x-config, i.e.
+    # everything downstream extension builds inherit (*_NODIST vars and the
+    # LLVM_PROF_* PGO leftovers are never used by extension builds)
+    toolchain_keys = (
+        "CC", "CXX", "CFLAGS", "CPPFLAGS", "CCSHARED", "LDSHARED",
+        "LDCXXSHARED", "BLDSHARED", "LINKCC", "LDFLAGS", "AR", "ARFLAGS",
+        "RANLIB", "READELF",
+    )
+    for key in toolchain_keys:
+        print(f"{key}={build_time_vars.get(key)}")
+    leaked = {
+        key: value
+        for key in toolchain_keys
+        if isinstance(value := build_time_vars.get(key), str)
+        and ("clang" in value or "lld" in value or "llvm" in value)
+    }
+    if leaked:
+        print(f"toolchain still leaks into sysconfig: {leaked}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is essentially what #365 does, but also cleans the Python sysconfigdata from clang specific build flags and sets the compiler/linker back to gcc. With this, the base image should be usable as a drop-in replacement: Wheels will continue to build just fine with gcc (as provided by Alpine's `build-base`, which our wheels builder and probably most apps are using).