### PR TITLE
python: 3.14: drop -fno-builtin malloc/calloc/realloc/free CFLAGS

### DIFF
--- a/python/3.14/Dockerfile
+++ b/python/3.14/Dockerfile
@@ -105,7 +105,7 @@ RUN \
         --without-static-libpython \
     && make -j "$(nproc)" \
         LDFLAGS="-Wl,--strip-all" \
-        CFLAGS="-fno-semantic-interposition -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free" \
+        CFLAGS="-fno-semantic-interposition" \
 # set thread stack size to 2MB so we don't segfault before we hit sys.getrecursionlimit()
 # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0
 # https://github.com/alpinelinux/aports/commit/675f1babb7ac89068d32b8f4b4e8bbfbb04c96ac


### PR DESCRIPTION
These flags stop the compiler from using its built-in knowledge of the malloc family, e.g. fusing malloc+memset into a single calloc call or removing allocations that are never used. Suppressing that is only needed when compiling code that *implements* malloc: there, fusing an allocator's internal malloc+memset into calloc makes it call itself and recurse. That is why allocator projects like TCMalloc and mimalloc use these flags for their own builds.

We picked them up in 24f3e8a ("Optimize python with LTO & no-semantic", July 2020, #82) together with -ljemalloc, when libpython was still linked against jemalloc directly. That guidance never really applied to us — CPython only ever *calls* malloc, it does not define it — and the -ljemalloc link has long since been replaced by LD_PRELOAD.

With jemalloc (or in the future mimalloc) interposed via LD_PRELOAD, anything the compiler fuses or elides still ends up in the preloaded allocator, so the flags add no safety. They only inhibit minor optimizations — in CPython itself and, via sysconfig, in every downstream extension build that inherits our CFLAGS.

-fno-semantic-interposition is unrelated and stays.